### PR TITLE
Added issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -1,0 +1,45 @@
+---
+name: Notify Bug Template
+about: Create a report to help us improve
+title: 'BUG: '
+labels: Notify
+assignees: ''
+
+---
+
+<!--
+Remove any comment indicators like the one above or below if you want to include a section. 
+We do not need what to write showing up in tickets though, so please do not uncomment those descriptions.
+-->
+
+## Description
+
+- [ ] Ticket is understood, and QA has been contacted (if the ticket has a QA label).
+
+<!--_**Required.** Describe the problem._-->
+
+## Steps to Reproduce
+<!--_**Required.** Provide information on what steps you are aware of that produce this undesired outcome.._-->
+
+1. 
+
+<!--
+## Workaround
+Is there something we can do to work around this issue in the meantime?
+-->
+
+## Impact/Urgency
+<!--_**Required.** Describe the impact this bug has on our system, clients, and/or team._-->
+
+## Expected Behavior
+<!--_**Required.** Describe the desired outcome if this were functioning as expected. Include a checklist if applicable._-->
+
+- [ ] 
+
+<!--
+## QA Considerations
+_For QA to populate. Leave blank if QA is not applicable on this ticket._
+-->
+
+## Additional Info & Resources
+<!--Always attempt to include additional information.  This could include screenshots, log snippets, links to applicable code files, and/or articles/websites that have relevant info on the issue. Leave blank if n/a.-->

--- a/.github/ISSUE_TEMPLATE/spike_template.md
+++ b/.github/ISSUE_TEMPLATE/spike_template.md
@@ -1,0 +1,42 @@
+---
+name: Notify Spike Template
+about: Used to find missing elements of functional and/or technical understanding.
+title: 'Spike: '
+labels: Notify
+assignees: ''
+
+---
+
+<!--
+Remove any comment indicators like the one above or below if you want to include a section. 
+We do not need what to write showing up in tickets though, so please do not uncomment those descriptions.
+-->
+
+## User Story - Business Goal
+
+- [ ] Ticket is understood, and QA has been contacted (if the ticket has a QA label).
+
+<!--_**Required.** Please note you can have more than one story, if applicable. If this is a technical investigation to achieve a larger initiative, the user story should represent that piece of the initiative._-->
+
+### User Story(ies)
+
+**As a**    <!-- describe the affected user --><br>
+**I want**  <!-- describe the need          --><br>
+**So that** <!-- describe the outcome]      --> 
+
+### Additional Info and Resources
+<!--Always attempt to include additional information.  This could include screenshots, log snippets, links to applicable code files, and/or articles/websites that have relevant info on the issue. Leave blank if n/a.-->
+
+## Acceptance Criteria & Checklist
+
+- [ ] Technical Documentation has been created and linked in the glossary
+- [ ] Learnings have been shared with the team, and decisions have been documented
+- [ ] Tickets for next steps have been identified and created
+
+Completed research addresses the problems and/or answers the questions below:  
+
+1. 
+
+<!--
+## Timebox
+Comment out if N/A -->

--- a/.github/ISSUE_TEMPLATE/story_template.md
+++ b/.github/ISSUE_TEMPLATE/story_template.md
@@ -1,0 +1,48 @@
+---
+name: Notify Story Template
+about: Default story card for new feature or enhancement requests
+title: ''
+labels: Notify
+assignees: ''
+
+---
+
+<!--
+Remove any comment indicators like the one above or below if you want to include a section. 
+We do not need what to write showing up in tickets though, so please do not uncomment those descriptions.
+-->
+
+## User Story - Business Need
+
+- [ ] Ticket is understood, and QA has been contacted (if the ticket has a QA label).
+
+<!--_**Required.** Please note you can have more than one story, if applicable. If this is technical work to achieve a larger initiative, the user story should represent that piece of the initiative so it’s clear what problem we are solving._-->
+
+### User Story(ies)
+
+**As a**    <!-- describe the affected user -->  
+**I want**  <!-- describe the need          -->  
+**So that** <!-- describe the outcome]      --> 
+
+### Additional Info and Resources
+<!--Always attempt to include additional information.  This could include screenshots, log snippets, links to applicable code files, and/or articles/websites that have relevant info on the issue. Leave blank if n/a.-->
+
+
+## Acceptance Criteria
+<!--_**Required**_
+- e.g. when I send an email using an identifier, we retrieve the user’s email address in VA Profile and successfully deliver the email to that recipient-->
+
+
+## QA Considerations
+<!--
+_Populate with relevant info for QA. Leave blank if QA is not applicable on this ticket._
+-->
+
+
+## Potential Dependencies
+<!-- Leave blank if n/a -->
+
+<!--
+## Out of Scope
+_Leave blank if n/a_
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+<!--
+Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
+-->
+
+# Description
+<!--
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+-->
+
+issue #(issue)
+
+## Type of change
+
+Please check the relevant option(s).
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Hotfix (quick fix for an urgent bug or issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Documentation changes only
+
+## How Has This Been Tested?
+<!--
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
+Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
+-->
+
+
+
+## Checklist
+
+- [ ] I have assigned myself to this PR
+- [ ] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
+- [ ] PR has a detailed description, including links to specific documentation
+- [ ] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
+- [ ] I did not remove any parts of the template, such as checkboxes even if they are not used
+- [ ] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to any documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
+- [ ] I have ensured the latest main is merged into my branch and all checks are green prior to review
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] The ticket is now moved into the DEV test column
+- [ ] I have added a bullet for this work to the Engineering Key Wins slide for review


### PR DESCRIPTION
Copied from notification-api repo. Followed the naming convention of the files used by github (underscores). 

FYSA: This method appears to be legacy, but it exceeded the scope of the intended work to upgrade to [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms).