### PR TITLE
#67 - Eliminate leaked semaphores and ensure FastAPI lifespan cleanup code executes on app exit

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -53,10 +53,12 @@ async def lifespan(app: CustomFastAPI) -> AsyncIterator[Never]:
     """
     await init_db()
 
-    yield  # type: ignore
-
-    app.enp_state.clear_providers()
-    await close_db()
+    try:
+        yield  # type: ignore
+    finally:
+        app.enp_state.clear_providers()
+        await close_db()
+        logger.info('AsyncContextManager lifespan shutdown complete')
 
 
 def create_app() -> CustomFastAPI:


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue #67 

This PR addresses a leaked semaphore warning observed when running the FastAPI app with Uvicorn's --reload option. While the semaphore warnings can be safely ignored, testing also uncovered that the lifespan cleanup phase was skipped if exceptions occurred during shutdown.

**Summary of Changes**

**1. Proposed changes to [WIKI](https://github.com/department-of-veterans-affairs/va-enp-api/wiki/Overview#running-app-outside-container-db-in-container)**
Change:
`poetry run uvicorn app.main:app --reload`
To:
`watchfiles "poetry run uvicorn app.main:app`
	- Updates startup command to use watchfiles directly instead of relying on Uvicorn’s --reload option, which caused semaphore warnings.

**2. Lifespan Cleanup Fix**
	- Wrapped the lifespan yield/cleanup logic in a try/finally block to ensure proper execution, following best practices.
	- Shutdown (with watchfiles) now raises CancelledError as expected, but resources are cleaned up properly.

**Note:**
**Running with watchfiles raises CancelledError, which is expected behavior.**

**References**

- [uvicorn --reload semaphore issue](https://github.com/encode/uvicorn/issues/679?utm_source=chatgpt.com)
	- Uvicorn’s multiprocessing-based file watchers allocate semaphores, leading to warnings at shutdown when terminated by Ctrl-C. These warnings are cosmetic and do not indicate an actual leak.

- [asyncio.CancelledError Documentation](https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.CancelledError)
	- `CancelledError` during shutdown is expected and reflects proper cleanup of asyncio event loops.

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Initial issue verified running locally and checking OS resources before and after execution

Start the database: `docker compose -f ci/docker-compose-local.yml up enp-db -d`

**1. No Resource Tracking, Lifespan Shutdown Completes (added additional logging)**

```bash
$ poetry run uvicorn app.main:app

$ ls -lc /dev/shm
total 0

Ctrl-C

^C2025-01-03 09:54:29.941 | INFO     | logging:callHandlers:1762 - Shutting down
2025-01-03 09:54:30.043 | INFO     | logging:callHandlers:1762 - Waiting for application shutdown.
2025-01-03 09:54:30.044 | INFO     | app.main:lifespan:61 - AsyncContextManager lifespan shutdown complete
2025-01-03 09:54:30.045 | INFO     | logging:callHandlers:1762 - Application shutdown complete.
2025-01-03 09:54:30.045 | INFO     | logging:callHandlers:1762 - Finished server process [107827]
```

Lifespan complete at info log message **app.main:lifespan:61 - AsyncContextManager lifespan shutdown complete**

**2. UVICORN --reload Resource Tracking, Leaked Semaphore Warning, and Skipped Lifespan Shutdown**
_note: leaked semaphores are cleaned up_

```bash
$ poetry run uvicorn app.main:app --reload

$ ls /dev/shm
sem.mp-39iv3ul9  sem.mp-7tgsrwo3  sem.mp-ae2tqc6l  sem.mp-f9m1pxgq  sem.mp-kg_lmtq8  sem.mp-oqixckaj  sem.mp-unyytcta  sem.mp-wxifmqpa
sem.mp-608qmp05  sem.mp-8a6glheo  sem.mp-d03e9pyh  sem.mp-i8oez7vv  sem.mp-l9216y8o  sem.mp-s8zoua_y  sem.mp-uurmjolb  sem.mp-zobgrjpy

Ctrl-C

^C2025-01-03 09:56:45.045 | INFO     | logging:callHandlers:1762 - Shutting down
INFO:     Stopping reloader process [108311]
/usr/lib/python3.12/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 16 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '

$ ls -lc /dev/shm
total 0
```

**3. Run Watchfiles Directly During Development**
Addresses semaphore warnings, but lifespan cleanup is still skipped.
_note: uvicorn --reload uses watchfiles internally_

```bash
$ watchfiles "poetry run uvicorn app.main:app"
...
^C[10:00:16] KeyboardInterrupt caught, stopping watch
2025-01-03 10:00:16.546 | INFO     | logging:callHandlers:1762 - Shutting down
2025-01-03 10:00:16.648 | INFO     | logging:callHandlers:1762 - Finished server process [109063]
2025-01-03 10:00:16.664 | ERROR    | logging:callHandlers:1762 - Traceback (most recent call last):
	...
	KeyboardInterrupt
	During handling of the above exception, another exception occurred:
	asyncio.exceptions.CancelledError
```

**4. Solution - Ensure Lifespan Cleanup Executes (watchfiles)**
Best practice: Wrap yield and cleanup in a try/finally block.
CancelledError still propagates as normal behavior.

```bash
$ watchfiles "poetry run uvicorn app.main:app"
...
^C[10:07:24] KeyboardInterrupt caught, stopping watch
2025-01-03 10:07:24.176 | INFO     | logging:callHandlers:1762 - Shutting down
2025-01-03 10:07:24.277 | INFO     | logging:callHandlers:1762 - Finished server process [110465]
**2025-01-03 10:07:24.279 | INFO     | app.main:lifespan:61 - AsyncContextManager lifespan shutdown complete**
2025-01-03 10:07:24.282 | ERROR    | logging:callHandlers:1762 - Traceback (most recent call last):
	...
	KeyboardInterrupt
	During handling of the above exception, another exception occurred:
	asyncio.exceptions.CancelledError
```

Lifespan complete at info log message **app.main:lifespan:61 - AsyncContextManager lifespan shutdown complete**

**5. Additional Testing - Clean exit without resource monitoring after adding try/finally**

```bash
$ poetry run uvicorn app.main:app

Ctrl-C

^C2025-01-03 16:12:13.178 | INFO     | logging:callHandlers:1762 - Shutting down
2025-01-03 16:12:13.279 | INFO     | logging:callHandlers:1762 - Waiting for application shutdown.
2025-01-03 16:12:13.281 | INFO     | app.main:lifespan:61 - AsyncContextManager lifespan shutdown complete
2025-01-03 16:12:13.281 | INFO     | logging:callHandlers:1762 - Application shutdown complete.
```

Lifespan complete at info log message **app.main:lifespan:61 - AsyncContextManager lifespan shutdown complete**

**6. Additional Testing - Lifespan clean up not executed with `uvicorn --reload` even with try/finally**
uvicorn --reload still skips the lifespan cleanup but this is expected behavior.

```bash
$ poetry run uvicorn app.main:app --reload

$ ls /dev/shm
sem.mp-39iv3ul9  sem.mp-7tgsrwo3  sem.mp-ae2tqc6l  sem.mp-f9m1pxgq  sem.mp-kg_lmtq8  sem.mp-oqixckaj  sem.mp-unyytcta  sem.mp-wxifmqpa
sem.mp-608qmp05  sem.mp-8a6glheo  sem.mp-d03e9pyh  sem.mp-i8oez7vv  sem.mp-l9216y8o  sem.mp-s8zoua_y  sem.mp-uurmjolb  sem.mp-zobgrjpy

Ctrl-C

^C2025-01-03 16:00:45.653 | INFO     | logging:callHandlers:1762 - Shutting down
INFO:     Stopping reloader process [177941]
/usr/lib/python3.12/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 16 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '

$ ls -lc /dev/shm
total 0
```

**Unit testing**

Shutdown execution identified with additional logging and [unittests](https://github.com/department-of-veterans-affairs/va-enp-api/actions/runs/12600787910/job/35120563762?pr=123#step:6:99)

Unit tests added to verify app exit with and without a raised CancelledError to ensure lifespan completes in both cases.

## Summary
**1. The CancelledError is normal behavior and reflects asyncio event loops cleaning up.**
**2. Simple alternative to seeing the CancelledError is to not run with resource monitoring and just restart app manually**

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
