### PR TITLE
#135 -  Implement RetryableError and NonRetryableError

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,12 +1,10 @@
 """Base classes for exceptions."""
 
-from typing import ANY
-
 
 class RetryableError(Exception):
     """Indicative of a retryable exception."""
 
-    def __init__(self, /, log_msg: str | None = None, *args: ANY, **kwargs: ANY) -> None:
+    def __init__(self, /, log_msg: str | None = None, *args: str, **kwargs: str) -> None:
         """Constructor."""
         self.log_msg = log_msg
         super().__init__(*args, **kwargs)
@@ -21,8 +19,8 @@ class NonRetryableError(Exception):
         log_msg: str | None = None,
         status: str | None = None,
         status_reason: str | None = None,
-        *args: ANY,
-        **kwargs: ANY,
+        *args: str,
+        **kwargs: str,
     ) -> None:
         """Constructor."""
         self.log_msg = log_msg

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,10 +1,12 @@
 """Base classes for exceptions."""
 
+from typing import Any
+
 
 class RetryableError(Exception):
     """Indicative of a retryable exception."""
 
-    def __init__(self, /, log_msg: str | None = None, *args: tuple, **kwargs: dict) -> None:
+    def __init__(self, /, log_msg: str | None = None, *args: tuple[Any], **kwargs: dict[Any, Any]) -> None:
         """Constructor.
 
         Arguments:
@@ -25,8 +27,8 @@ class NonRetryableError(Exception):
         log_msg: str | None = None,
         status: str | None = None,
         status_reason: str | None = None,
-        *args: tuple,
-        **kwargs: dict,
+        *args: tuple[Any],
+        **kwargs: dict[Any, Any],
     ) -> None:
         """Constructor.
 

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -5,7 +5,13 @@ class RetryableError(Exception):
     """Indicative of a retryable exception."""
 
     def __init__(self, /, log_msg: str | None = None, *args: str, **kwargs: str) -> None:
-        """Constructor."""
+        """Constructor.
+
+        Arguments:
+            log_msg: Additional information for the logs
+            *args: Self-explanatory
+            **kwargs: Self-explanatory
+        """
         self.log_msg = log_msg
         super().__init__(*args, **kwargs)
 
@@ -22,7 +28,15 @@ class NonRetryableError(Exception):
         *args: str,
         **kwargs: str,
     ) -> None:
-        """Constructor."""
+        """Constructor.
+
+        Arguments:
+            log_msg: Additional information for the logs
+            status: The notification status
+            status_reason: The reason for the notification status
+            *args: Self-explanatory
+            **kwargs: Self-explanatory
+        """
         self.log_msg = log_msg
         self.status = status
         self.status_reason = status_reason

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -4,7 +4,7 @@
 class RetryableError(Exception):
     """Indicative of a retryable exception."""
 
-    def __init__(self, /, log_msg: str | None = None, *args: str, **kwargs: str) -> None:
+    def __init__(self, /, log_msg: str | None = None, *args: tuple, **kwargs: dict) -> None:
         """Constructor.
 
         Arguments:
@@ -25,8 +25,8 @@ class NonRetryableError(Exception):
         log_msg: str | None = None,
         status: str | None = None,
         status_reason: str | None = None,
-        *args: str,
-        **kwargs: str,
+        *args: tuple,
+        **kwargs: dict,
     ) -> None:
         """Constructor.
 

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,13 +1,31 @@
 """Base classes for exceptions."""
 
+from typing import ANY
+
 
 class RetryableError(Exception):
     """Indicative of a retryable exception."""
 
-    ...
+    def __init__(self, /, log_msg: str | None = None, *args: ANY, **kwargs: ANY) -> None:
+        """Constructor."""
+        self.log_msg = log_msg
+        super().__init__(*args, **kwargs)
 
 
 class NonRetryableError(Exception):
     """Indicative of a non-retryable exception."""
 
-    ...
+    def __init__(
+        self,
+        /,
+        log_msg: str | None = None,
+        status: str | None = None,
+        status_reason: str | None = None,
+        *args: ANY,
+        **kwargs: ANY,
+    ) -> None:
+        """Constructor."""
+        self.log_msg = log_msg
+        self.status = status
+        self.status_reason = status_reason
+        super().__init__(*args, **kwargs)

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,0 +1,13 @@
+"""Base classes for exceptions."""
+
+
+class RetryableError(Exception):
+    """Indicative of a retryable exception."""
+
+    ...
+
+
+class NonRetryableError(Exception):
+    """Indicative of a non-retryable exception."""
+
+    ...

--- a/app/legacy/v2/notifications/utils.py
+++ b/app/legacy/v2/notifications/utils.py
@@ -7,8 +7,8 @@ from pydantic import UUID4
 from sqlalchemy.exc import NoResultFound
 
 from app.constants import NotificationType
-from app.exceptions import NonRetryableError, RetryableError
 from app.db.models import Template
+from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.templates_dao import LegacyTemplateDao
 from app.legacy.v2.notifications.route_schema import PersonalisationFileObject
 from app.providers.provider_aws import ProviderAWS

--- a/app/legacy/v2/notifications/utils.py
+++ b/app/legacy/v2/notifications/utils.py
@@ -7,11 +7,11 @@ from pydantic import UUID4
 from sqlalchemy.exc import NoResultFound
 
 from app.constants import NotificationType
+from app.exceptions import NonRetryableError, RetryableError
 from app.db.models import Template
 from app.legacy.dao.templates_dao import LegacyTemplateDao
 from app.legacy.v2.notifications.route_schema import PersonalisationFileObject
 from app.providers.provider_aws import ProviderAWS
-from app.providers.provider_base import ProviderNonRetryableError, ProviderRetryableError
 from app.providers.provider_schemas import PushModel
 
 
@@ -37,8 +37,8 @@ async def send_push_notification_helper(
     try:
         await provider.send_notification(push_model)
     except (
-        ProviderRetryableError,
-        ProviderNonRetryableError,
+        RetryableError,
+        NonRetryableError,
     ) as error:
         # when these are raised we want to set the message | include status reason and log message
         logger.exception(

--- a/tests/app/legacy/v2/notifications/test_utils.py
+++ b/tests/app/legacy/v2/notifications/test_utils.py
@@ -64,9 +64,9 @@ class TestSendPushNotificationHelper:
         mock_template.build_message.return_value = 'test_message'
         mock_provider = AsyncMock(spec=ProviderAWS)
         mock_provider.send_notification.side_effect = NonRetryableError
-        personalization: dict[str, str | int | float] = {'name': 'John'}
+        personalisation: dict[str, str | int | float] = {'name': 'John'}
 
-        await send_push_notification_helper(personalization, '12345', mock_template, mock_provider)
+        await send_push_notification_helper(personalisation, '12345', mock_template, mock_provider)
 
         mock_logger.assert_called_once()
 

--- a/tests/app/legacy/v2/notifications/test_utils.py
+++ b/tests/app/legacy/v2/notifications/test_utils.py
@@ -9,6 +9,7 @@ from pydantic import UUID4
 from sqlalchemy.exc import NoResultFound
 
 from app.constants import NotificationType
+from app.exceptions import NonRetryableError
 from app.db.models import Template
 from app.legacy.v2.notifications.utils import (
     _validate_template_active,
@@ -20,7 +21,6 @@ from app.legacy.v2.notifications.utils import (
     validate_template,
 )
 from app.providers.provider_aws import ProviderAWS
-from app.providers.provider_base import ProviderNonRetryableError
 
 
 async def test_get_arn_from_icn_not_implemented() -> None:
@@ -63,8 +63,8 @@ class TestSendPushNotificationHelper:
         mock_template = AsyncMock(spec=Template)
         mock_template.build_message.return_value = 'test_message'
         mock_provider = AsyncMock(spec=ProviderAWS)
-        mock_provider.send_notification.side_effect = ProviderNonRetryableError
-        personalisation: dict[str, str | int | float] = {'name': 'John'}
+        mock_provider.send_notification.side_effect = NonRetryableError
+        personalization: dict[str, str | int | float] = {'name': 'John'}
 
         await send_push_notification_helper(personalisation, '12345', mock_template, mock_provider)
 

--- a/tests/app/legacy/v2/notifications/test_utils.py
+++ b/tests/app/legacy/v2/notifications/test_utils.py
@@ -9,8 +9,8 @@ from pydantic import UUID4
 from sqlalchemy.exc import NoResultFound
 
 from app.constants import NotificationType
-from app.exceptions import NonRetryableError
 from app.db.models import Template
+from app.exceptions import NonRetryableError
 from app.legacy.v2.notifications.utils import (
     _validate_template_active,
     _validate_template_personalisation,
@@ -66,7 +66,7 @@ class TestSendPushNotificationHelper:
         mock_provider.send_notification.side_effect = NonRetryableError
         personalization: dict[str, str | int | float] = {'name': 'John'}
 
-        await send_push_notification_helper(personalisation, '12345', mock_template, mock_provider)
+        await send_push_notification_helper(personalization, '12345', mock_template, mock_provider)
 
         mock_logger.assert_called_once()
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

These changes replace the custom exceptions "ProviderNonRetryableError" and "ProviderRetryableError" with the more general "NonRetryableError" and "RetryableError".  The latter exceptions have custom attributes.

The file app/exceptions.py contains the docstrings "Constructor." because ruff requires a docstring.  Otherwise, I would have omitted the docstrings because their purpose is obvious.  Ditto for the annotations for *args and **kwargs.  See [here](https://docs.astral.sh/ruff/rules/missing-type-args/) and [here](https://docs.astral.sh/ruff/rules/missing-type-kwargs/).

issue #135

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

All unit tests continue to pass.

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
