### PR TITLE
#175 - Ensure v2 and legacy/v2 error structure matches NAPI

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -63,9 +63,9 @@ class JWTBearer(HTTPBearer):
         """
         credentials: HTTPAuthorizationCredentials | None = await super(JWTBearer, self).__call__(request)
         if credentials is None:
-            logger.warning('No credentials provided.')
+            logger.info('No credentials provided.')
             raise HTTPException(status_code=401, detail='Unauthorized, authentication token must be provided')
         if not verify_token(str(credentials.credentials)):
-            logger.warning('Invalid or expired token.')
+            logger.info('Invalid or expired token.')
             raise HTTPException(status_code=403, detail='Invalid token: signature, api token is not valid')
         return credentials

--- a/app/auth.py
+++ b/app/auth.py
@@ -64,8 +64,8 @@ class JWTBearer(HTTPBearer):
         credentials: HTTPAuthorizationCredentials | None = await super(JWTBearer, self).__call__(request)
         if credentials is None:
             logger.warning('No credentials provided.')
-            raise HTTPException(status_code=403, detail='Not authenticated')
+            raise HTTPException(status_code=401, detail='Unauthorized, authentication token must be provided')
         if not verify_token(str(credentials.credentials)):
             logger.warning('Invalid or expired token.')
-            raise HTTPException(status_code=403, detail='Invalid or expired token.')
+            raise HTTPException(status_code=403, detail='Invalid token: signature, api token is not valid')
         return credentials

--- a/app/legacy/v2/notifications/rest.py
+++ b/app/legacy/v2/notifications/rest.py
@@ -107,7 +107,7 @@ async def create_sms_notification(
         error_details = {
             'errors': [
                 {
-                    'error': 'BadRequestError',
+                    'error': 'ValidationError',
                     'message': str(e),
                 },
             ],

--- a/app/legacy/v2/notifications/rest.py
+++ b/app/legacy/v2/notifications/rest.py
@@ -20,12 +20,12 @@ from app.legacy.v2.notifications.route_schema import (
     ValidatedPhoneNumber,
 )
 from app.legacy.v2.notifications.utils import send_push_notification_helper, validate_template
-from app.routers import TimedAPIRoute
+from app.routers import LegacyTimedAPIRoute
 
 v2_legacy_notification_router = APIRouter(
     dependencies=[Depends(JWTBearer())],
     prefix='/legacy/v2/notifications',
-    route_class=TimedAPIRoute,
+    route_class=LegacyTimedAPIRoute,
     tags=['v2 Legacy Notification Endpoints'],
 )
 
@@ -33,7 +33,7 @@ v2_legacy_notification_router = APIRouter(
 v2_notification_router = APIRouter(
     dependencies=[Depends(JWTBearer())],
     prefix='/v2/notifications',
-    route_class=TimedAPIRoute,
+    route_class=LegacyTimedAPIRoute,
     tags=['v2 Notification Endpoints'],
 )
 

--- a/app/legacy/v2/notifications/rest.py
+++ b/app/legacy/v2/notifications/rest.py
@@ -3,7 +3,7 @@
 from typing import Annotated
 from uuid import uuid4
 
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, Request, status
 from loguru import logger
 from pydantic import UUID4
 
@@ -19,7 +19,11 @@ from app.legacy.v2.notifications.route_schema import (
     V2Template,
     ValidatedPhoneNumber,
 )
-from app.legacy.v2.notifications.utils import send_push_notification_helper, validate_template
+from app.legacy.v2.notifications.utils import (
+    raise_request_validation_error,
+    send_push_notification_helper,
+    validate_template,
+)
 from app.routers import LegacyTimedAPIRoute
 
 v2_legacy_notification_router = APIRouter(
@@ -92,28 +96,13 @@ async def create_sms_notification(
 
     Returns:
         V2PostSmsResponseModel: The notification response data if notification is created successfully.
-
-    Raises:
-        HTTPException: If the template is not found, is not a SMS type, or is not active, or if the request is
-            missing personalisation data.
-
     """
     logger.debug('Received SMS request with data: {}', request)
 
     try:
         await validate_template(request.template_id, NotificationType.SMS, request.personalisation)
     except ValueError as e:
-        # Error details based on consistency with the flask api v2 response
-        error_details = {
-            'errors': [
-                {
-                    'error': 'ValidationError',
-                    'message': str(e),
-                },
-            ],
-            'status_code': status.HTTP_400_BAD_REQUEST,
-        }
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_details)
+        raise_request_validation_error(str(e))
 
     logger.debug('Creating SMS notification with request data {}.', request)
 

--- a/app/legacy/v2/notifications/route_schema.py
+++ b/app/legacy/v2/notifications/route_schema.py
@@ -302,7 +302,7 @@ class V2PostSmsRequestModel(V2PostNotificationRequestModel):
 
         """
         if self.phone_number is None and self.recipient_identifier is None:
-            raise ValueError('You must specify at least one of "phone_number" or "recipient identifier".')
+            raise ValueError('You must specify at least one of phone_number or recipient identifier.')
         return self
 
 

--- a/app/legacy/v2/notifications/route_schema.py
+++ b/app/legacy/v2/notifications/route_schema.py
@@ -224,7 +224,6 @@ class V2PostEmailRequestModel(V2PostNotificationRequestModel):
     """Attributes specific to requests to send e-mail notifications."""
 
     email_address: EmailStr | None = None
-    email_reply_to_id: Annotated[UUID4, Field(strict=False)] | None = None
 
     @model_validator(mode='after')
     def email_or_recipient_id(self) -> Self:

--- a/app/legacy/v2/notifications/route_schema.py
+++ b/app/legacy/v2/notifications/route_schema.py
@@ -218,13 +218,13 @@ class V2PostNotificationRequestModel(StrictBaseModel):
     reference: str | None = None
     template_id: Annotated[UUID4, Field(strict=False)]
     scheduled_for: Annotated[AwareDatetime, Field(strict=False)] | None = None
-    email_reply_to_id: Annotated[UUID4, Field(strict=False)] | None = None
 
 
 class V2PostEmailRequestModel(V2PostNotificationRequestModel):
     """Attributes specific to requests to send e-mail notifications."""
 
     email_address: EmailStr | None = None
+    email_reply_to_id: Annotated[UUID4, Field(strict=False)] | None = None
 
     @model_validator(mode='after')
     def email_or_recipient_id(self) -> Self:

--- a/app/legacy/v2/notifications/route_schema.py
+++ b/app/legacy/v2/notifications/route_schema.py
@@ -246,7 +246,6 @@ class V2PostEmailRequestModel(V2PostNotificationRequestModel):
 class V2PostSmsRequestModel(V2PostNotificationRequestModel):
     """Attributes specific to requests to send SMS notifications."""
 
-    # phone_number: PhoneNumberE164 | None = None
     phone_number: ValidatedPhoneNumber | None = None
     sms_sender_id: Annotated[UUID4, Field(strict=False)] | None = None
 

--- a/app/legacy/v2/notifications/utils.py
+++ b/app/legacy/v2/notifications/utils.py
@@ -1,7 +1,9 @@
 """Utilities to aid the REST Notification routes."""
 
 import re
+from typing import Sequence
 
+from fastapi.exceptions import RequestValidationError
 from loguru import logger
 from pydantic import UUID4
 from sqlalchemy.exc import NoResultFound
@@ -12,6 +14,24 @@ from app.legacy.dao.templates_dao import LegacyTemplateDao
 from app.legacy.v2.notifications.route_schema import PersonalisationFileObject
 from app.providers.provider_aws import ProviderAWS
 from app.providers.provider_schemas import PushModel
+
+
+def raise_request_validation_error(
+    message: str,
+    loc: Sequence[str] = ('body',),
+) -> None:
+    """Raise a FastAPI-style RequestValidationError with a message and optional location.
+
+    Args:
+        message (str): The error message.
+        loc (Sequence[str]): A sequence of strings describing the field path.
+
+    Raises:
+        RequestValidationError: Handled by router to return properly structured JSON
+    """
+    error = {'loc': loc, 'msg': message, 'type': 'value_error'}
+
+    raise RequestValidationError(errors=[error])
 
 
 async def send_push_notification_helper(

--- a/app/legacy/v2/notifications/utils.py
+++ b/app/legacy/v2/notifications/utils.py
@@ -102,7 +102,7 @@ async def validate_template(
 ) -> None:
     """Validates the template with the given ID.
 
-    Checks for the template in the database, that it's the right type, and is active. Raises an HTTPException if any
+    Checks for the template in the database, that it's the right type, and is active. Raises a ValueError if any
     of these conditions are not met.
 
     Args:

--- a/app/routers.py
+++ b/app/routers.py
@@ -40,9 +40,9 @@ class LegacyTimedAPIRoute(APIRoute):
                 # special case to override status code and message to match v2
                 e.status_code = 401
                 e.detail = 'Unauthorized, authentication token must be provided'
-                error_type = 'AuthError'
+            error_type = 'AuthError'
 
-        errors = {'errors': [{'error': error_type, 'msg': e.detail}], 'status_code': e.status_code}
+        errors = {'errors': [{'error': error_type, 'message': e.detail}], 'status_code': e.status_code}
         return JSONResponse(status_code=e.status_code, content=errors)
 
     @staticmethod

--- a/app/routers.py
+++ b/app/routers.py
@@ -12,6 +12,104 @@ from loguru import logger
 from app.constants import RESPONSE_400
 
 
+class LegacyTimedAPIRoute(APIRoute):
+    """Exception and logging handling for v2/legacy."""
+
+    @staticmethod
+    def http_exception_handler(request: Request, e: HTTPException) -> JSONResponse:
+        """Log and handle HTTPException errors.
+
+        Args:
+            request (Request): The original request data.
+            e (HTTPException): The exception data.
+
+        Returns:
+            JSONResponse: The JSON response when v2 validation errors are present.
+        """
+        logger.warning(
+            'Request: {} {} Failed with HTTPException: {}',
+            request.method,
+            request.url,
+            e,
+        )
+
+        # Return the JSON response for v2 compatibility
+        if isinstance(e.detail, dict) and e.detail.get('errors'):
+            return JSONResponse(status_code=e.status_code, content=e.detail)
+        else:
+            raise e
+
+    @staticmethod
+    def request_validation_error_handler(request: Request, e: RequestValidationError) -> JSONResponse:
+        """Log and handle RequestValidationError errors.
+
+        Convert Pydantic/FastAPI errors structure to a v2 json response.
+
+        Args:
+            request (Request): The original request data.
+            e (RequestValidationError): The exception data.
+
+        Returns:
+            JSONResponse: The JSON response when validation errors are present.
+        """
+        status_code = status.HTTP_400_BAD_REQUEST
+
+        logger.warning(
+            'Request: {} {} Failed validation: {}',
+            request.method,
+            request.url,
+            e,
+        )
+
+        errors = []
+
+        for error in e.errors():
+            if error.get('type') == 'missing':
+                # need to construct message for missing/field required errors
+                field_loc = error.get('loc')
+                field_name = field_loc[-1] if field_loc else 'unknown_field'
+                message = f'The required field {field_name} is missing.'
+            else:
+                message = error.get('msg')
+
+            errors.append({'error': 'ValidationError', 'message': message})
+
+        return JSONResponse(status_code=status_code, content={'errors': errors, 'status_code': status_code})
+
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        """Override default handler.
+
+        Returns:
+            Callable: the route handler
+
+        """
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            status_code = None
+            try:
+                start = monotonic()
+                resp = await original_route_handler(request)
+                status_code = resp.status_code
+                return resp
+            except RequestValidationError as e:
+                status_code = status.HTTP_400_BAD_REQUEST
+                return self.request_validation_error_handler(request, e)
+            except HTTPException as e:
+                status_code = e.status_code
+                return self.http_exception_handler(request, e)
+            finally:
+                logger.info(
+                    '{} {} {} {}s',
+                    request.method,
+                    request.url,
+                    status_code,
+                    f'{(monotonic() - start):6f}',
+                )
+
+        return custom_route_handler
+
+
 class TimedAPIRoute(APIRoute):
     """Exception and logging handling."""
 

--- a/app/routers.py
+++ b/app/routers.py
@@ -60,7 +60,7 @@ class LegacyTimedAPIRoute(APIRoute):
         """
         status_code = status.HTTP_400_BAD_REQUEST
 
-        logger.warning(
+        logger.info(
             'Request: {} {} Failed validation: {}',
             request.method,
             request.url,

--- a/app/routers.py
+++ b/app/routers.py
@@ -70,10 +70,10 @@ class LegacyTimedAPIRoute(APIRoute):
         errors = []
 
         for error in e.errors():
-            error_location = error.get('loc')
+            error_location = error.get('loc', ())
             error_message = error.get('msg')
 
-            if error.get('type').startswith('uuid'):
+            if error.get('type', '').startswith('uuid'):
                 # special case to override Pydantic UUID type/format message
                 error_message = 'Input should be a valid UUID version 4'
 

--- a/tests/app/legacy/v2/notifications/test_rest.py
+++ b/tests/app/legacy/v2/notifications/test_rest.py
@@ -149,14 +149,11 @@ class TestNotificationRouter:
             route (str): Route to test
 
         """
-        template_id = uuid4()
-        sms_sender_id = uuid4()
-
         request = V2PostSmsRequestModel(
             reference=str(uuid4()),
-            template_id=template_id,
+            template_id=uuid4(),
             phone_number=ValidatedPhoneNumber('+18005550101'),
-            sms_sender_id=sms_sender_id,
+            sms_sender_id=uuid4(),
         )
         payload = jsonable_encoder(request)
         with patch('app.legacy.v2.notifications.rest.validate_template', return_value=None):

--- a/tests/app/legacy/v2/notifications/test_rest.py
+++ b/tests/app/legacy/v2/notifications/test_rest.py
@@ -137,7 +137,7 @@ class TestNotificationRouter:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     @pytest.mark.parametrize('route', routes)
-    async def test_401_path(
+    async def test_auth_error_uses_v2_json_structure(
         self,
         client: ENPTestClient,
         route: str,

--- a/tests/app/legacy/v2/notifications/test_rest.py
+++ b/tests/app/legacy/v2/notifications/test_rest.py
@@ -162,7 +162,18 @@ class TestNotificationRouter:
         with patch('app.legacy.v2.notifications.rest.validate_template', return_value=None):
             response = client.post(route, json=payload, headers={'Authorization': ''})
 
+        error_details = {
+            'errors': [
+                {
+                    'error': 'AuthError',
+                    'message': 'Unauthorized, authentication token must be provided',
+                },
+            ],
+            'status_code': 401,
+        }
+
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.json() == error_details
 
 
 @patch('app.legacy.v2.notifications.rest.validate_template', return_value=None)

--- a/tests/app/legacy/v2/notifications/test_rest.py
+++ b/tests/app/legacy/v2/notifications/test_rest.py
@@ -145,7 +145,7 @@ class TestV2SMS:
     error_details: ClassVar = {
         'errors': [
             {
-                'error': 'BadRequestError',
+                'error': 'ValidationError',
                 'message': '',
             },
         ],

--- a/tests/app/legacy/v2/notifications/test_rest.py
+++ b/tests/app/legacy/v2/notifications/test_rest.py
@@ -264,7 +264,7 @@ class TestV2SMS:
         client: ENPTestClient,
         sms_request_data: dict[str, str],
     ) -> None:
-        """Test route returns 400 with invalid personalisation."""
+        """Test route returns 400 and custom UUID formatting message."""
         sms_request_data['template_id'] = 'bad_uuid'
 
         response = client.post(self.sms_route, json=sms_request_data)

--- a/tests/app/legacy/v2/notifications/test_route_schema.py
+++ b/tests/app/legacy/v2/notifications/test_route_schema.py
@@ -37,7 +37,6 @@ VALID_ICN_VALUE = '1234567890V123456'
 )
 def test_v2_post_email_request_model_valid(data: dict[str, str | dict[str, str]]) -> None:
     """Valid data with an e-mail address should not raise ValidationError."""
-    data['email_reply_to_id'] = str(uuid4())
     data['template_id'] = str(uuid4())
     assert isinstance(V2PostEmailRequestModel.model_validate(data), V2PostEmailRequestModel)
 
@@ -55,7 +54,6 @@ def test_v2_post_email_request_model_valid(data: dict[str, str | dict[str, str]]
 )
 def test_v2_post_email_request_model_invalid(data: dict[str, str | dict[str, str]]) -> None:
     """Invalid data should raise ValidationError."""
-    data['email_reply_to_id'] = str(uuid4())
     data['template_id'] = str(uuid4())
 
     with pytest.raises(ValidationError):

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -30,8 +30,8 @@ def test_credentials_returns_none(client: TestClient, mocker: AsyncMock) -> None
     """
     mocker.patch('app.auth.HTTPBearer.__call__', return_value=None)
     response = client.post('/v3/device-registrations')
-    assert response.status_code == 403
-    assert response.json() == {'detail': 'Not authenticated'}
+    assert response.status_code == 401
+    assert response.json() == {'detail': 'Unauthorized, authentication token must be provided'}
 
 
 def test_missing_authorization_scheme(client: TestClient) -> None:
@@ -61,7 +61,7 @@ def test_expired_iat_in_token(client: TestClient) -> None:
         '/v3/device-registrations', headers={'Authorization': f'Bearer {generate_token(payload=payload)}'}
     )
     assert response.status_code == 403
-    assert response.json() == {'detail': 'Invalid or expired token.'}
+    assert response.json() == {'detail': 'Invalid token: signature, api token is not valid'}
 
 
 def test_future_iat_in_token(client: TestClient) -> None:
@@ -80,4 +80,4 @@ def test_future_iat_in_token(client: TestClient) -> None:
         '/v3/device-registrations', headers={'Authorization': f'Bearer {generate_token(payload=payload)}'}
     )
     assert response.status_code == 403
-    assert response.json() == {'detail': 'Invalid or expired token.'}
+    assert response.json() == {'detail': 'Invalid token: signature, api token is not valid'}


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

To achieve parity with the notification-api, the ENP error response messages need to match the format of the notification-api, which they currently do not.

- Error response structure and key fields updated to match notification-api
- Error message strings updated to the satisfaction of QA, even though they differ
- Created LegacyTimedAPIRoute, copying original functionality but encapsulating v2 error response compatibility
- Cleaned out unused error handling paths from TimedAPIRoute that were v2 specific
- Added helper function to raise properly formatted request validation errors

issue #175 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Unit tests updated to use v2 JSON responses

### Local testing

Required test coverage of 100.0% reached. Total coverage: 100.00%
==== 226 passed in 1.70s ====

Tested all cases listed in QA document [post_sms_error_messages](https://github.com/department-of-veterans-affairs/vanotify-team/wiki/post_sms_error_messages)

Results of local testing detailed in comments of ticket

QA advised of and accepted new message detail strings

### ENP Dev testing

QA ran test suite to validate all documented error responses on deploy ENP-DEV

![image](https://github.com/user-attachments/assets/f1c5a635-5498-4255-b097-73ce47c1205e)

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
