### PR TITLE
#272 Added SMS Sender ID Functionality 

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: poetry.lock
-  checksum: 56213588f7fc12b5a2acde43e0582dcef4e29949e5db09552bb223d1d9399c4a
+  checksum: 96bd61724a37a63566f1fb1f52e740d6b405a3a705c720a7612c55e283001540
 - filename: postman/enp-api.postman_collection.json
   checksum: a75beb668be832bdb38484e044987be0ace21a597fa1aa30ba837d3bfc94a0c7
 - filename: tests/app/legacy/dao/conftest.py
@@ -30,15 +30,17 @@ fileignoreconfig:
 - filename: app/legacy/dao/notifications_dao.py
   checksum: 5519ec1bf2a863cb8e5a7a4a225db4a4d0ce7f97ce49d6caf445e4a887c47aef
 - filename: app/auth.py
-  checksum: bd65417f924018a0417557fbc608769dbe9ae56312e7a2f7c96f82264bd2d818
+  checksum: 45c7a96a5c5aaf6af5168b24625c7561a992cbe6bc516f4c55667ff76dde1fd7
 - filename: tests/conftest.py
   checksum: c39c4b3e4777417f7b302794e869c272c2175d27dbc5236f85d4ecf9668dbe0d
 - filename: tests/napi_table_data.toml
   checksum: db0b29eb4c9c25867f0aa0fd4ae5bacceed1cea95c33602274bacf31f073aa0b
 - filename: tests/app/legacy/v2/notifications/test_rest.py
-  checksum: 1cb3438564a64fb4fca2873315b71863401cafb50e27163d590e1e06f2e29e0b
+  checksum: be7fe988e19ccd447cca130915c9a2052208297580573179a6da9aeca48f0352
 - filename: tests/app/test_auth.py
-  checksum: 8394b5cb4cac2d352bcc2d84988d81540a58dae7f3cbe22e881833d2eb1e9a75
+  checksum: 4afa019ce45edf17b74925c5b92dae24e1f4ef53cd579d52286fe09415a58646
 - filename: tests/app/legacy/v2/notifications/test_utils.py
-  checksum: d8967b47122115e2c42335aad0325bc50785633ab1d89a6e52bd149baed653a3
+  checksum: c18b734f3d91923174ef8260a918b45eebdb872b7b656ac266b5a915f14ab31f
+- filename: app/legacy/v2/notifications/utils.py
+  checksum: 0fa791627c35746bebd1e338372c04b9b4e71e06fbedb4f8730b5c7e2bb5cae7
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: poetry.lock
-  checksum: 96bd61724a37a63566f1fb1f52e740d6b405a3a705c720a7612c55e283001540
+  checksum: c931c7a49f3e91802ffe82cc5d7d40c0198d4c880983875b35c8da4814931d8c
 - filename: postman/enp-api.postman_collection.json
   checksum: a75beb668be832bdb38484e044987be0ace21a597fa1aa30ba837d3bfc94a0c7
 - filename: tests/app/legacy/dao/conftest.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,7 @@
 fileignoreconfig:
 - filename: poetry.lock
-  checksum: c931c7a49f3e91802ffe82cc5d7d40c0198d4c880983875b35c8da4814931d8c
+  checksum: 14aaa474c1ad01deab49d8822a058d0057ea95349190211970fb1f03f038bd6a
+  ignore_detectors: []  # Ignore everything
 - filename: postman/enp-api.postman_collection.json
   checksum: a75beb668be832bdb38484e044987be0ace21a597fa1aa30ba837d3bfc94a0c7
 - filename: tests/app/legacy/dao/conftest.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -7,7 +7,7 @@ fileignoreconfig:
 - filename: tests/app/legacy/dao/conftest.py
   checksum: c82f4eb2f484f6465fa50bb5bbbff6152c84fe4071e3724a0d91124049a2fad9
 - filename: app/legacy/dao/api_keys_dao.py
-  checksum: 460fc7fbfb35b1b87b282a7cddf3e1a14e79e9ba478e8f39d47d04b6b836f7a5
+  checksum: 9f11c845ba2a49530816867abfab4c12817db01f89f365e6a5641539e516216e
 - filename: tests/app/providers/__init__.py
   checksum: 0e3ae2fd3a50245a8c143d31c4316b164b51161d2db6e660aa956b78eda1b4d8
 - filename: tests/app/providers/test_provider_aws.py
@@ -19,7 +19,7 @@ fileignoreconfig:
 - filename: app/legacy/dao/api_key_dao.py
   checksum: 9eb496d3ae4238193baf5c5627d8d186beeda815133e9b4e1bc6e56ce57a3802
 - filename: tests/app/legacy/dao/test_api_keys.py
-  checksum: 30f8d4b5117cb785cb962d93cb89c056067184e8572f0550a7223dec9507fa5e
+  checksum: c08a73f7e31069462f1ed336e33485ee9ef4bdae9ff70d0691684df361777fc7
 - filename: tests/app/legacy/v2/notifications/test_auth.py
   checksum: 9a46795e0124515bc5960deee90d0a7531aaff989c39b4ecc93ab8c9f1969942
 - filename: .env.local
@@ -31,7 +31,7 @@ fileignoreconfig:
 - filename: app/legacy/dao/notifications_dao.py
   checksum: 5519ec1bf2a863cb8e5a7a4a225db4a4d0ce7f97ce49d6caf445e4a887c47aef
 - filename: app/auth.py
-  checksum: 45c7a96a5c5aaf6af5168b24625c7561a992cbe6bc516f4c55667ff76dde1fd7
+  checksum: fa5256f19e5afb2115af5dc6b2b69984eb1f16642a801daed4ba72298c5fe4a2
 - filename: tests/conftest.py
   checksum: c39c4b3e4777417f7b302794e869c272c2175d27dbc5236f85d4ecf9668dbe0d
 - filename: tests/napi_table_data.toml
@@ -39,7 +39,7 @@ fileignoreconfig:
 - filename: tests/app/legacy/v2/notifications/test_rest.py
   checksum: be7fe988e19ccd447cca130915c9a2052208297580573179a6da9aeca48f0352
 - filename: tests/app/test_auth.py
-  checksum: 4afa019ce45edf17b74925c5b92dae24e1f4ef53cd579d52286fe09415a58646
+  checksum: 760334bef0bf6ebf446fee7f7aef7d902ad06f5e18b80816816d2b12c5035285
 - filename: tests/app/legacy/v2/notifications/test_utils.py
   checksum: c18b734f3d91923174ef8260a918b45eebdb872b7b656ac266b5a915f14ab31f
 - filename: app/legacy/v2/notifications/utils.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -7,7 +7,7 @@ fileignoreconfig:
 - filename: tests/app/legacy/dao/conftest.py
   checksum: c82f4eb2f484f6465fa50bb5bbbff6152c84fe4071e3724a0d91124049a2fad9
 - filename: app/legacy/dao/api_keys_dao.py
-  checksum: 173b55053300c426cb1cd313eb6e998c8adb7c1c8d2ca42ddd75bd6772a0140f
+  checksum: 460fc7fbfb35b1b87b282a7cddf3e1a14e79e9ba478e8f39d47d04b6b836f7a5
 - filename: tests/app/providers/__init__.py
   checksum: 0e3ae2fd3a50245a8c143d31c4316b164b51161d2db6e660aa956b78eda1b4d8
 - filename: tests/app/providers/test_provider_aws.py

--- a/app/auth.py
+++ b/app/auth.py
@@ -33,8 +33,6 @@ from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.api_keys_dao import ApiKeyRecord, LegacyApiKeysDao
 from app.legacy.dao.services_dao import LegacyServiceDao
 
-# from app.legacy.dao.utils import db_5m_cache, db_12h_cache
-
 ADMIN_CLIENT_USER_NAME = os.getenv('ENP_ADMIN_CLIENT_USER_NAME', 'enp')
 ADMIN_SECRET_KEY = os.getenv('ENP_ADMIN_SECRET_KEY', 'not-very-secret')
 ALGORITHM = os.getenv('ENP_ALGORITHM', 'HS256')

--- a/app/auth.py
+++ b/app/auth.py
@@ -209,7 +209,7 @@ async def get_active_service_for_issuer(issuer: str) -> tuple[UUID4, str]:
         issuer (str): The issuer value extracted from a JWT token, expected to be a UUID4 string.
 
     Returns:
-        uple[UUID4, str]: A SQLAlchemy Core row representing the active service associated with the given issuer.
+        Tuple[UUID4, str]: A SQLAlchemy Core row representing the active service associated with the given issuer.
 
     Raises:
         HTTPException:
@@ -217,10 +217,7 @@ async def get_active_service_for_issuer(issuer: str) -> tuple[UUID4, str]:
             - 403 if the service is not found.
             - 403 if the service is found but marked as archived (inactive).
     """
-    logger.debug(
-        'Attempting to lookup service by issuer: {}',
-        issuer,
-    )
+    logger.debug('Attempting to lookup service by issuer: {}', issuer)
 
     try:
         service_id = UUID4(issuer)
@@ -237,11 +234,7 @@ async def get_active_service_for_issuer(issuer: str) -> tuple[UUID4, str]:
             status_code=status.HTTP_403_FORBIDDEN, detail=RESPONSE_LEGACY_INVALID_TOKEN_ARCHIVED_SERVICE
         )
 
-    logger.debug(
-        'Found service service_id: {} for issuer: {}',
-        service.id,
-        issuer,
-    )
+    logger.debug('Found service service_id: {} for issuer: {}', service.id, issuer)
 
     return service.id, service.name
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -10,7 +10,6 @@ import jwt
 from async_lru import alru_cache
 from fastapi import HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from loguru import logger
 from pydantic import UUID4
 from sqlalchemy import Row
 from starlette_context import context
@@ -32,6 +31,7 @@ from app.constants import (
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.api_keys_dao import ApiKeyRecord, LegacyApiKeysDao
 from app.legacy.dao.services_dao import LegacyServiceDao
+from app.logging.logging_config import logger
 
 ADMIN_CLIENT_USER_NAME = os.getenv('ENP_ADMIN_CLIENT_USER_NAME', 'enp')
 ADMIN_SECRET_KEY = os.getenv('ENP_ADMIN_SECRET_KEY', 'not-very-secret')

--- a/app/auth.py
+++ b/app/auth.py
@@ -27,7 +27,6 @@ from app.constants import (
     RESPONSE_LEGACY_INVALID_TOKEN_REVOKED,
     RESPONSE_LEGACY_INVALID_TOKEN_WRONG_TYPE,
     RESPONSE_LEGACY_NO_CREDENTIALS,
-    TWELVE_HOURS,
 )
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.api_keys_dao import ApiKeyRecord, LegacyApiKeysDao
@@ -196,7 +195,6 @@ async def verify_service_token(issuer: str, token: str) -> None:
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=RESPONSE_LEGACY_INVALID_TOKEN_NOT_FOUND)
 
 
-@alru_cache(maxsize=1024, ttl=TWELVE_HOURS)
 async def get_active_service_for_issuer(issuer: str) -> tuple[UUID4, str]:
     """Validate the given issuer string as a UUID4 and return the corresponding active service.
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -285,17 +285,17 @@ def _validate_service_api_key(api_key: ApiKeyRecord, service_id: str, service_na
 
     if api_key.expiry_date is not None and api_key.expiry_date < datetime.now(timezone.utc):
         logger.warning(
-            'service {} - {} used expired api key {} expired as of {}',
-            service_id,
+            '({}) service {} - used expired api key {} expired as of {}',
             service_name,
+            service_id,
             api_key.id,
             api_key.expiry_date,
         )
     elif api_key.expiry_date is None:
         logger.warning(
-            'service {} - {} used old-style api key {} with no expiry_date',
-            service_id,
+            '({}) service {} - used old-style api key {} with no expiry_date',
             service_name,
+            service_id,
             api_key.id,
         )
 

--- a/app/clients/va_profile.py
+++ b/app/clients/va_profile.py
@@ -3,9 +3,8 @@
 - register_device_with_vaprofile: Register a device with VA Profile.
 """
 
-from loguru import logger
-
 from app.constants import MobileAppType, OSPlatformType
+from app.logging.logging_config import logger
 
 
 def register_device_with_vaprofile(

--- a/app/constants.py
+++ b/app/constants.py
@@ -13,10 +13,9 @@ AWS_REGION = os.getenv('AWS_REGION', 'us-east-1')
 # Defaulting to 3 so local testing doesn't take too long.
 MAX_RETRIES = int(os.getenv('MAX_RETRIES', 3))
 
-RESPONSE_400 = 'Bad request'
-RESPONSE_403 = 'Not authenticated'
-RESPONSE_404 = 'Not found'
-RESPONSE_500 = 'Server error'
+# Time calculations
+FIVE_MINUTES = 5 * 60
+TWELVE_HOURS = 12 * 60 * 60
 
 
 class AttachmentType(StrEnum):
@@ -86,3 +85,9 @@ RESPONSE_LEGACY_INVALID_TOKEN_NO_KEYS = 'Invalid token: service has no API keys'
 RESPONSE_LEGACY_INVALID_TOKEN_REVOKED = 'Invalid token: API key revoked'  # nosec
 RESPONSE_LEGACY_ERROR_SYSTEM_CLOCK = 'Error: Your system clock must be accurate to within 30 seconds'
 RESPONSE_LEGACY_NO_CREDENTIALS = 'Unauthorized, authentication token must be provided'
+
+# ENP responses
+RESPONSE_400 = 'Bad request'
+RESPONSE_403 = 'Not authenticated'
+RESPONSE_404 = 'Not found'
+RESPONSE_500 = 'Server error'

--- a/app/db/db_init.py
+++ b/app/db/db_init.py
@@ -4,7 +4,6 @@ from asyncio import current_task
 from typing import AsyncIterator
 
 from fastapi.concurrency import asynccontextmanager
-from loguru import logger
 from sqlalchemy import MetaData
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -15,6 +14,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from app.db import NAPI_DB_READ_URI, NAPI_DB_WRITE_URI
+from app.logging.logging_config import logger
 
 _engine_napi_read: AsyncEngine | None = None
 _engine_napi_write: AsyncEngine | None = None

--- a/app/legacy/dao/api_keys_dao.py
+++ b/app/legacy/dao/api_keys_dao.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Sequence
 
-from loguru import logger
 from pydantic import UUID4
 from sqlalchemy import Row, select
 from sqlalchemy.exc import (
@@ -19,6 +18,7 @@ from sqlalchemy.exc import (
 from app.db.db_init import get_read_session_with_context, metadata_legacy
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.utils import db_retry
+from app.logging.logging_config import logger
 
 
 class LegacyApiKeysDao:

--- a/app/legacy/dao/api_keys_dao.py
+++ b/app/legacy/dao/api_keys_dao.py
@@ -53,8 +53,8 @@ class LegacyApiKeysDao:
             service_id (UUID4): The service id to get keys for
 
         Raises:
-            NonRetryableError: If this is not retryable
-            RetryableError: If this is retryable
+            NonRetryableError: If the error is non-retryable
+            RetryableError: If the error is retryable
 
         Returns:
             Sequence[Row[Any]]: Iterable of Service rows

--- a/app/legacy/dao/api_keys_dao.py
+++ b/app/legacy/dao/api_keys_dao.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Sequence
 
+from async_lru import alru_cache
 from loguru import logger
 from pydantic import UUID4
 from sqlalchemy import Row, select
@@ -16,8 +17,10 @@ from sqlalchemy.exc import (
     TimeoutError,
 )
 
+from app.constants import FIVE_MINUTES
 from app.db.db_init import get_read_session_with_context, metadata_legacy
 from app.exceptions import NonRetryableError, RetryableError
+from app.legacy.dao.utils import db_retry
 
 
 class LegacyApiKeysDao:
@@ -42,15 +45,8 @@ class LegacyApiKeysDao:
             RetryableError: If the failure is likely transient (e.g., connection error).
             NonRetryableError: If the failure is deterministic (e.g., bad input).
         """
-        legacy_api_keys = metadata_legacy.tables['api_keys']
-        stmt = select(legacy_api_keys).where(legacy_api_keys.c.service_id == service_id)
-
         try:
-            async with get_read_session_with_context() as session:
-                result = await session.execute(stmt)
-
-            return result.fetchall()
-
+            return await _get_api_keys_for_service(service_id)
         except DataError as e:
             # Deterministic and will likely fail again
             logger.exception(
@@ -67,6 +63,26 @@ class LegacyApiKeysDao:
         except SQLAlchemyError as e:
             logger.exception('Uexpected SQLAlchemy error during service API keys lookup for service_id: {}', service_id)
             raise NonRetryableError('Uexpected SQLAlchemy error during service API keys lookup.') from e
+
+
+@db_retry
+@alru_cache(maxsize=1024, ttl=FIVE_MINUTES)
+async def _get_api_keys_for_service(service_id: UUID4) -> Sequence[Row[Any]]:
+    """Retryable and cached function to get a ApiKey row.
+
+    Args:
+        service_id (UUID4): The api key UUID
+
+    Returns:
+        Row[Any]: A ApiKey row
+    """
+    legacy_api_keys = metadata_legacy.tables['api_keys']
+    stmt = select(legacy_api_keys).where(legacy_api_keys.c.service_id == service_id)
+
+    async with get_read_session_with_context() as session:
+        result = await session.execute(stmt)
+
+    return result.fetchall()
 
 
 @dataclass

--- a/app/legacy/dao/notifications_dao.py
+++ b/app/legacy/dao/notifications_dao.py
@@ -30,7 +30,7 @@ class LegacyNotificationDao:
     """
 
     @staticmethod
-    async def get_notification(id: UUID4) -> Row[Any]:
+    async def get(id: UUID4) -> Row[Any]:
         """Get a Notification from the legacy database.
 
         Args:
@@ -43,11 +43,10 @@ class LegacyNotificationDao:
             Row[Any]: notification table row
         """
         try:
-            row: Row[Any] = await LegacyNotificationDao._get(id)
+            return await LegacyNotificationDao._get(id)
         except (RetryableError, NonRetryableError) as e:
             # Exceeded retries or was never retryable. Downstream methods logged this
             raise NonRetryableError from e
-        return row
 
     @db_retry
     @staticmethod

--- a/app/legacy/dao/notifications_dao.py
+++ b/app/legacy/dao/notifications_dao.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 from typing import Any
 
-from loguru import logger
 from pydantic import UUID4
 from sqlalchemy import Row, delete, select
 from sqlalchemy.dialects.postgresql import insert
@@ -20,6 +19,7 @@ from app.constants import NotificationStatus, NotificationType
 from app.db.db_init import get_read_session_with_context, get_write_session_with_context, metadata_legacy
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.utils import db_retry
+from app.logging.logging_config import logger
 
 
 class LegacyNotificationDao:

--- a/app/legacy/dao/notifications_dao.py
+++ b/app/legacy/dao/notifications_dao.py
@@ -80,6 +80,7 @@ class LegacyNotificationDao:
         reply_to_text: str,
         service_id: UUID4,
         api_key_id: UUID4,
+        reference: str | None,
         template_id: UUID4,
         template_version: int,
         billable_units: int = 0,
@@ -94,6 +95,7 @@ class LegacyNotificationDao:
             reply_to_text (str): Origination phone, email, etc.
             service_id (UUID4): The service id
             api_key_id (UUID4): The api key id
+            reference (str | None): Client provided reference
             template_id (UUID4): The template id
             template_version (int): The template version
             billable_units (int, optional): How many billable units this is. Defaults to 0.
@@ -117,6 +119,7 @@ class LegacyNotificationDao:
         reply_to_text: str,
         service_id: UUID4,
         api_key_id: UUID4,
+        reference: str | None,
         template_id: UUID4,
         template_version: int,
         billable_units: int,
@@ -132,6 +135,7 @@ class LegacyNotificationDao:
                     reply_to_text=reply_to_text,
                     service_id=service_id,
                     api_key_id=api_key_id,
+                    reference=reference,
                     template_id=template_id,
                     template_version=template_version,
                     billable_units=billable_units,

--- a/app/legacy/dao/service_sms_sender_dao.py
+++ b/app/legacy/dao/service_sms_sender_dao.py
@@ -36,11 +36,10 @@ class LegacyServiceSmsSenderDao:
             Row[Any]: service_sms_senders table row
         """
         try:
-            row: Row[Any] = await LegacyServiceSmsSenderDao._get(id)
+            return await LegacyServiceSmsSenderDao._get(id)
         except (RetryableError, NonRetryableError) as e:
             # Exceeded retries or was never retryable. Downstream methods logged this
             raise NonRetryableError from e
-        return row
 
     @staticmethod
     async def get_service_default(service_id: UUID4) -> Row[Any]:
@@ -56,11 +55,10 @@ class LegacyServiceSmsSenderDao:
             Row[Any]: service_sms_senders table row
         """
         try:
-            row: Row[Any] = await LegacyServiceSmsSenderDao._get_service_default(service_id)
+            return await LegacyServiceSmsSenderDao._get_service_default(service_id)
         except (RetryableError, NonRetryableError) as e:
             # Exceeded retries or was never retryable. Downstream methods logged this
             raise NonRetryableError from e
-        return row
 
     @db_retry
     @staticmethod

--- a/app/legacy/dao/service_sms_sender_dao.py
+++ b/app/legacy/dao/service_sms_sender_dao.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-from loguru import logger
 from pydantic import UUID4
 from sqlalchemy import Row, select
 from sqlalchemy.exc import (
@@ -17,6 +16,7 @@ from sqlalchemy.exc import (
 from app.db.db_init import get_read_session_with_context, metadata_legacy
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.utils import db_retry
+from app.logging.logging_config import logger
 
 
 class LegacyServiceSmsSenderDao:

--- a/app/legacy/dao/service_sms_sender_dao.py
+++ b/app/legacy/dao/service_sms_sender_dao.py
@@ -73,17 +73,17 @@ class LegacyServiceSmsSenderDao:
 
         except (IntegrityError, DataError) as e:
             # These are deterministic and will likely fail again
-            logger.exception('Notification lookup failed: invalid or unexpected data for id: {}', id)
-            raise NonRetryableError('Notification lookup failed: invalid or unexpected data.') from e
+            logger.exception('Service lookup failed: invalid or unexpected data for id: {}', id)
+            raise NonRetryableError('Service lookup failed: invalid or unexpected data.') from e
 
         except (OperationalError, InterfaceError, TimeoutError) as e:
             # Transient DB issues that may succeed on retry
-            logger.warning('Notification lookup failed due to a transient database error for id: {}', id)
-            raise RetryableError('Notification lookup failed due to a transient database error.') from e
+            logger.warning('Service lookup failed due to a transient database error for id: {}', id)
+            raise RetryableError('Service lookup failed due to a transient database error.') from e
 
         except SQLAlchemyError as e:
-            logger.exception('Unexpected SQLAlchemy error during notification lookup for id: {}', id)
-            raise NonRetryableError('Unexpected SQLAlchemy error during notification lookup.') from e
+            logger.exception('Unexpected SQLAlchemy error during service lookup for id: {}', id)
+            raise NonRetryableError('Unexpected SQLAlchemy error during service lookup.') from e
 
     @db_retry
     @staticmethod
@@ -100,14 +100,14 @@ class LegacyServiceSmsSenderDao:
 
         except (IntegrityError, DataError) as e:
             # These are deterministic and will likely fail again
-            logger.exception('Notification lookup failed: invalid or unexpected data for id: {}', id)
-            raise NonRetryableError('Notification lookup failed: invalid or unexpected data.') from e
+            logger.exception('Service lookup failed: invalid or unexpected data for id: {}', id)
+            raise NonRetryableError('Service lookup failed: invalid or unexpected data.') from e
 
         except (OperationalError, InterfaceError, TimeoutError) as e:
             # Transient DB issues that may succeed on retry
-            logger.warning('Notification lookup failed due to a transient database error for id: {}', id)
-            raise RetryableError('Notification lookup failed due to a transient database error.') from e
+            logger.warning('Service lookup failed due to a transient database error for id: {}', id)
+            raise RetryableError('Service lookup failed due to a transient database error.') from e
 
         except SQLAlchemyError as e:
-            logger.exception('Unexpected SQLAlchemy error during notification lookup for id: {}', id)
-            raise NonRetryableError('Unexpected SQLAlchemy error during notification lookup.') from e
+            logger.exception('Unexpected SQLAlchemy error during service lookup for id: {}', id)
+            raise NonRetryableError('Unexpected SQLAlchemy error during service lookup.') from e

--- a/app/legacy/dao/service_sms_sender_dao.py
+++ b/app/legacy/dao/service_sms_sender_dao.py
@@ -1,0 +1,113 @@
+"""The data access objects for notifications."""
+
+from typing import Any
+
+from loguru import logger
+from pydantic import UUID4
+from sqlalchemy import Row, select
+from sqlalchemy.exc import (
+    DataError,
+    IntegrityError,
+    InterfaceError,
+    OperationalError,
+    SQLAlchemyError,
+    TimeoutError,
+)
+
+from app.db.db_init import get_read_session_with_context, metadata_legacy
+from app.exceptions import NonRetryableError, RetryableError
+from app.legacy.dao.utils import db_retry
+
+
+class LegacyServiceSmsSenderDao:
+    """A class to handle the data access for service_sms_sender data in the legacy database."""
+
+    @staticmethod
+    async def get(id: UUID4) -> Row[Any]:
+        """Get a ServiceSmsSender from the legacy database.
+
+        Args:
+            id (UUID4): id of the ServiceSmsSender
+
+        Raises:
+            NonRetryableError: Unable to get the service
+
+        Returns:
+            Row[Any]: service_sms_senders table row
+        """
+        try:
+            row: Row[Any] = await LegacyServiceSmsSenderDao._get(id)
+        except (RetryableError, NonRetryableError) as e:
+            # Exceeded retries or was never retryable. Downstream methods logged this
+            raise NonRetryableError from e
+        return row
+
+    @staticmethod
+    async def get_service_default(service_id: UUID4) -> Row[Any]:
+        """Get a ServiceSmsSender from the legacy database.
+
+        Args:
+            service_id (UUID4): id of the service
+
+        Raises:
+            NonRetryableError: Unable to get the service
+
+        Returns:
+            Row[Any]: service_sms_senders table row
+        """
+        try:
+            row: Row[Any] = await LegacyServiceSmsSenderDao._get_service_default(service_id)
+        except (RetryableError, NonRetryableError) as e:
+            # Exceeded retries or was never retryable. Downstream methods logged this
+            raise NonRetryableError from e
+        return row
+
+    @db_retry
+    @staticmethod
+    async def _get(id: UUID4) -> Row[Any]:
+        legacy_service_sms_senders = metadata_legacy.tables['service_sms_senders']
+        try:
+            stmt = select(legacy_service_sms_senders).where(legacy_service_sms_senders.c.id == id)
+            async with get_read_session_with_context() as session:
+                return (await session.execute(stmt)).one()
+
+        except (IntegrityError, DataError) as e:
+            # These are deterministic and will likely fail again
+            logger.exception('Notification lookup failed: invalid or unexpected data for id: {}', id)
+            raise NonRetryableError('Notification lookup failed: invalid or unexpected data.') from e
+
+        except (OperationalError, InterfaceError, TimeoutError) as e:
+            # Transient DB issues that may succeed on retry
+            logger.warning('Notification lookup failed due to a transient database error for id: {}', id)
+            raise RetryableError('Notification lookup failed due to a transient database error.') from e
+
+        except SQLAlchemyError as e:
+            logger.exception('Unexpected SQLAlchemy error during notification lookup for id: {}', id)
+            raise NonRetryableError('Unexpected SQLAlchemy error during notification lookup.') from e
+
+    @db_retry
+    @staticmethod
+    async def _get_service_default(service_id: UUID4) -> Row[Any]:
+        legacy_service_sms_senders = metadata_legacy.tables['service_sms_senders']
+        try:
+            stmt = (
+                select(legacy_service_sms_senders)
+                .where(legacy_service_sms_senders.c.service_id == service_id)
+                .where(legacy_service_sms_senders.c.is_default)
+            )
+            async with get_read_session_with_context() as session:
+                return (await session.execute(stmt)).one()
+
+        except (IntegrityError, DataError) as e:
+            # These are deterministic and will likely fail again
+            logger.exception('Notification lookup failed: invalid or unexpected data for id: {}', id)
+            raise NonRetryableError('Notification lookup failed: invalid or unexpected data.') from e
+
+        except (OperationalError, InterfaceError, TimeoutError) as e:
+            # Transient DB issues that may succeed on retry
+            logger.warning('Notification lookup failed due to a transient database error for id: {}', id)
+            raise RetryableError('Notification lookup failed due to a transient database error.') from e
+
+        except SQLAlchemyError as e:
+            logger.exception('Unexpected SQLAlchemy error during notification lookup for id: {}', id)
+            raise NonRetryableError('Unexpected SQLAlchemy error during notification lookup.') from e

--- a/app/legacy/dao/services_dao.py
+++ b/app/legacy/dao/services_dao.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-from loguru import logger
 from pydantic import UUID4
 from sqlalchemy import Row, select
 from sqlalchemy.exc import (
@@ -18,6 +17,7 @@ from sqlalchemy.exc import (
 from app.db.db_init import get_read_session_with_context, metadata_legacy
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.utils import db_retry
+from app.logging.logging_config import logger
 
 
 class LegacyServiceDao:
@@ -55,8 +55,8 @@ class LegacyServiceDao:
             id (UUID4): The service id to get
 
         Raises:
-            NonRetryableError: Cannot be retried
-            RetryableError: Retryable
+            NonRetryableError: If the error is non-retryable
+            RetryableError: If the error is retryable
 
         Returns:
             Row[Any]: Service row

--- a/app/legacy/dao/services_dao.py
+++ b/app/legacy/dao/services_dao.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-from async_lru import alru_cache
 from loguru import logger
 from pydantic import UUID4
 from sqlalchemy import Row, select
@@ -16,7 +15,6 @@ from sqlalchemy.exc import (
     TimeoutError,
 )
 
-from app.constants import TWELVE_HOURS
 from app.db.db_init import get_read_session_with_context, metadata_legacy
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.utils import db_retry
@@ -30,50 +28,56 @@ class LegacyServiceDao:
     """
 
     @staticmethod
-    async def get_service(service_id: UUID4) -> Row[Any]:
+    async def get(id: UUID4) -> Row[Any]:
         """Retrieve a single service row by its ID.
 
         Args:
-            service_id (UUID4): The unique identifier of the service to retrieve.
+            id (UUID4): The unique identifier of the service to retrieve.
 
         Returns:
             Row[Any]: A SQLAlchemy Core Row object containing the service data.
 
         Raises:
-            RetryableError: If the failure is likely transient (e.g., connection error).
             NonRetryableError: If the failure is deterministic (e.g., not found, bad input).
         """
         try:
-            return await _get_service(service_id)
+            return await LegacyServiceDao._get(id)
+        except (RetryableError, NonRetryableError) as e:
+            # Exceeded retries or was never retryable. Downstream methods logged this
+            raise NonRetryableError from e
+
+    @db_retry
+    @staticmethod
+    async def _get(id: UUID4) -> Row[Any]:
+        """Retryable and cached function to get a Service row.
+
+        Args:
+            id (UUID4): The service id to get
+
+        Raises:
+            NonRetryableError: Cannot be retried
+            RetryableError: Retryable
+
+        Returns:
+            Row[Any]: Service row
+        """
+        # Retryable and cached function to get a Service row.
+        legacy_services = metadata_legacy.tables['services']
+        try:
+            stmt = select(legacy_services).where(legacy_services.c.id == id)
+            async with get_read_session_with_context() as session:
+                return (await session.execute(stmt)).one()
+
         except (NoResultFound, MultipleResultsFound, DataError) as e:
             # These are deterministic and will likely fail again
-            logger.exception('Service lookup failed: invalid or unexpected data for service_id: {}', service_id)
+            logger.exception('Service lookup failed: invalid or unexpected data for id: {}', id)
             raise NonRetryableError('Service lookup failed: invalid or unexpected data.') from e
 
         except (OperationalError, InterfaceError, TimeoutError) as e:
             # Transient DB issues that may succeed on retry
-            logger.warning('Service lookup failed due to a transient database error for service_id: {}', service_id)
+            logger.warning('Service lookup failed due to a transient database error for id: {}', id)
             raise RetryableError('Service lookup failed due to a transient database error.') from e
 
         except SQLAlchemyError as e:
-            logger.exception('Unexpected SQLAlchemy error during service lookup for service_id: {}', service_id)
+            logger.exception('Unexpected SQLAlchemy error during service lookup for id: {}', id)
             raise NonRetryableError('Unexpected SQLAlchemy error during service lookup.') from e
-
-
-@db_retry
-@alru_cache(maxsize=1024, ttl=TWELVE_HOURS)
-async def _get_service(service_id: UUID4) -> Row[Any]:
-    """Retryable and cached function to get a Service row.
-
-    Args:
-        service_id (UUID4): The service UUID
-
-    Returns:
-        Row[Any]: A Service row
-    """
-    legacy_services = metadata_legacy.tables['services']
-    stmt = select(legacy_services).where(legacy_services.c.id == service_id)
-
-    async with get_read_session_with_context() as session:
-        result = await session.execute(stmt)
-    return result.one()

--- a/app/legacy/dao/templates_dao.py
+++ b/app/legacy/dao/templates_dao.py
@@ -4,8 +4,19 @@ from typing import Any
 
 from pydantic import UUID4
 from sqlalchemy import Row, select
+from sqlalchemy.exc import (
+    DataError,
+    InterfaceError,
+    MultipleResultsFound,
+    NoResultFound,
+    OperationalError,
+    SQLAlchemyError,
+    TimeoutError,
+)
 
 from app.db.db_init import get_read_session_with_context, metadata_legacy
+from app.exceptions import NonRetryableError, RetryableError
+from app.legacy.dao.utils import db_retry
 from app.logging.logging_config import logger
 
 
@@ -17,18 +28,55 @@ class LegacyTemplateDao:
     """
 
     @staticmethod
-    async def get_template(id: UUID4) -> Row[Any]:
+    async def get(id: UUID4) -> Row[Any]:
+        """Retrieve a single templaet row by its ID.
+
+        Args:
+            id (UUID4): The unique identifier of the templaet to retrieve.
+
+        Returns:
+            Row[Any]: A SQLAlchemy Core Row object containing the templaet data.
+
+        Raises:
+            NonRetryableError: If the failure is deterministic (e.g., not found, bad input).
+        """
+        try:
+            return await LegacyTemplateDao._get(id)
+        except (RetryableError, NonRetryableError) as e:
+            # Exceeded retries or was never retryable. Downstream methods logged this
+            raise NonRetryableError from e
+
+    @db_retry
+    @staticmethod
+    async def _get(id: UUID4) -> Row[Any]:
         """Get a Template from the legacy database.
 
         Args:
-            id (UUID4): id of the template
+            id (UUID4): The template id
+
+        Raises:
+            NonRetryableError: This is a non-retryable error
+            RetryableError: This is a retryable error
 
         Returns:
-            Row: template table row
+            Row[Any]: Template row
         """
-        logger.debug('Getting template {} from legacy database', id)
-        async with get_read_session_with_context() as session:
-            legacy_templates = metadata_legacy.tables['templates']
+        legacy_templates = metadata_legacy.tables['templates']
+        try:
             stmt = select(legacy_templates).where(legacy_templates.c.id == id)
-            logger.debug('Executing query: {}', stmt)
-            return (await session.execute(stmt)).one()
+            async with get_read_session_with_context() as session:
+                return (await session.execute(stmt)).one()
+
+        except (NoResultFound, MultipleResultsFound, DataError) as e:
+            # These are deterministic and will likely fail again
+            logger.exception('Template lookup failed: invalid or unexpected data for id: {}', id)
+            raise NonRetryableError('Template lookup failed: invalid or unexpected data.') from e
+
+        except (OperationalError, InterfaceError, TimeoutError) as e:
+            # Transient DB issues that may succeed on retry
+            logger.warning('Template lookup failed due to a transient database error for id: {}', id)
+            raise RetryableError('Template lookup failed due to a transient database error.') from e
+
+        except SQLAlchemyError as e:
+            logger.exception('Unexpected SQLAlchemy error during template lookup for id: {}', id)
+            raise NonRetryableError('Unexpected SQLAlchemy error during template lookup.') from e

--- a/app/legacy/dao/utils.py
+++ b/app/legacy/dao/utils.py
@@ -1,11 +1,5 @@
 """Legacy dao utility helpers."""
 
-import functools
-from typing import Any
-
-from cachetools import TTLCache
-from pydantic import UUID4
-from sqlalchemy import Row
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
 from app.exceptions import RetryableError
@@ -15,17 +9,10 @@ _MAX_DB_RETRIES = 3  # Arbitrary
 
 
 # Database retry parameters
-db_retry = functools.partial(
-    retry,
+db_retry = retry(
     before_sleep=log_on_retry,
     reraise=True,
     retry_error_callback=log_last_attempt_on_failure,
     retry=retry_if_exception_type(RetryableError),
     stop=stop_after_attempt(_MAX_DB_RETRIES),
 )
-
-_12_hours = float(12 * 60 * 60)
-_5_minutes = float(5 * 60)
-
-db_12h_cache: TTLCache[str, tuple[UUID4, str]] = TTLCache(maxsize=1024, ttl=_12_hours)
-db_5m_cache: TTLCache[str, str | list[Row[Any]]] = TTLCache(maxsize=1024, ttl=_5_minutes)

--- a/app/legacy/dao/utils.py
+++ b/app/legacy/dao/utils.py
@@ -1,7 +1,11 @@
 """Legacy dao utility helpers."""
 
 import functools
+from typing import Any
 
+from cachetools import TTLCache
+from pydantic import UUID4
+from sqlalchemy import Row
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
 from app.exceptions import RetryableError
@@ -19,3 +23,9 @@ db_retry = functools.partial(
     retry=retry_if_exception_type(RetryableError),
     stop=stop_after_attempt(_MAX_DB_RETRIES),
 )
+
+_12_hours = float(12 * 60 * 60)
+_5_minutes = float(5 * 60)
+
+db_12h_cache: TTLCache[str, tuple[UUID4, str]] = TTLCache(maxsize=1024, ttl=_12_hours)
+db_5m_cache: TTLCache[str, str | list[Row[Any]]] = TTLCache(maxsize=1024, ttl=_5_minutes)

--- a/app/legacy/v2/notifications/route_schema.py
+++ b/app/legacy/v2/notifications/route_schema.py
@@ -5,7 +5,6 @@ from typing import Annotated, Any, ClassVar, Collection, Literal
 
 from async_lru import alru_cache
 from fastapi import HTTPException, status
-from loguru import logger
 from phonenumbers import PhoneNumber
 from pydantic import (
     UUID4,
@@ -29,6 +28,7 @@ from app.exceptions import NonRetryableError
 from app.legacy.dao.service_sms_sender_dao import LegacyServiceSmsSenderDao
 from app.legacy.dao.templates_dao import LegacyTemplateDao
 from app.legacy.v2.notifications.validators import is_valid_recipient_id_value
+from app.logging.logging_config import logger
 
 
 class StrictBaseModel(BaseModel):

--- a/app/legacy/v2/notifications/route_schema.py
+++ b/app/legacy/v2/notifications/route_schema.py
@@ -28,8 +28,6 @@ from app.constants import FIVE_MINUTES, IdentifierType, MobileAppType, Notificat
 from app.exceptions import NonRetryableError
 from app.legacy.dao.service_sms_sender_dao import LegacyServiceSmsSenderDao
 from app.legacy.dao.templates_dao import LegacyTemplateDao
-
-# from app.legacy.dao.utils import db_12h_cache
 from app.legacy.v2.notifications.validators import is_valid_recipient_id_value
 
 

--- a/app/legacy/v2/notifications/route_schema.py
+++ b/app/legacy/v2/notifications/route_schema.py
@@ -288,7 +288,7 @@ class V2PostEmailRequestModel(V2PostNotificationRequestModel):
         Returns:
             str: The reply to string
         """
-        return str((await LegacyTemplateDao.get_template(self.template_id)).reply_to_text)
+        return str((await LegacyTemplateDao.get(self.template_id)).reply_to_text)
 
     def get_direct_contact_info(self) -> str | None:
         """Get the direct contact info from the request.

--- a/app/legacy/v2/notifications/route_schema.py
+++ b/app/legacy/v2/notifications/route_schema.py
@@ -3,6 +3,9 @@
 import re
 from typing import Annotated, Any, ClassVar, Collection, Literal
 
+from cachetools import cached
+from fastapi import HTTPException, status
+from loguru import logger
 from phonenumbers import PhoneNumber
 from pydantic import (
     UUID4,
@@ -18,10 +21,14 @@ from pydantic import (
 )
 from pydantic_core import PydanticCustomError, core_schema
 from pydantic_extra_types.phone_numbers import PhoneNumberValidator
+from starlette_context import context
 from typing_extensions import Self
 
 from app.constants import IdentifierType, MobileAppType, NotificationType
+from app.exceptions import NonRetryableError
+from app.legacy.dao.service_sms_sender_dao import LegacyServiceSmsSenderDao
 from app.legacy.dao.templates_dao import LegacyTemplateDao
+from app.legacy.dao.utils import db_12h_cache
 from app.legacy.v2.notifications.validators import is_valid_recipient_id_value
 
 
@@ -364,11 +371,22 @@ class V2PostSmsRequestModel(V2PostNotificationRequestModel):
     async def get_reply_to_text(self) -> str:
         """Get the reply_to_text field for this request.
 
+        Raises:
+            HTTPException: Return that this was a bad request
+
         Returns:
             str: The reply to string
         """
-        # TODO: #272 - Comes from sms_sender_id in the request or the Service. service_sms_sender.sender
-        return ''
+        sender: str
+        try:
+            sender = await _get_sms_sender(self.sms_sender_id, context['service_id'])
+        except NonRetryableError:
+            logger.info('Unable to find ServiceSmsSender')
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f'sms_sender_id {self.sms_sender_id} does not exist in database for service id {context["service_id"]}',
+            )
+        return sender
 
     def get_direct_contact_info(self) -> str | None:
         """Get the direct contact info from the request.
@@ -385,6 +403,27 @@ class V2PostSmsRequestModel(V2PostNotificationRequestModel):
             NotificationType: The channel for this type of request
         """
         return NotificationType.SMS
+
+
+@cached(db_12h_cache)
+async def _get_sms_sender(sms_sender_id: UUID4 | None, service_id: UUID4) -> str:
+    """Get the sms_sender of a ServiceSmsSender.
+
+        Moved outside the class due to caching issues.
+
+    Args:
+        sms_sender_id (UUID4 | None): The id to check if it is there
+        service_id (UUID4): The fallback id
+
+    Returns:
+        str: A string representing a PhoneNumber, PoolId, etc.
+    """
+    sender: str
+    if sms_sender_id is not None:
+        sender = (await LegacyServiceSmsSenderDao.get(sms_sender_id)).sms_sender
+    else:
+        sender = (await LegacyServiceSmsSenderDao.get_service_default(service_id)).sms_sender
+    return sender
 
 
 ##################################################

--- a/app/legacy/v2/notifications/utils.py
+++ b/app/legacy/v2/notifications/utils.py
@@ -124,7 +124,7 @@ async def validate_template(
         Row[Any]: A template row
     """
     try:
-        template = await LegacyTemplateDao.get_template(template_id)
+        template = await LegacyTemplateDao.get(template_id)
     except NoResultFound:
         logger.exception('Template not found with ID {}', template_id)
         raise_request_validation_error('Template not found')

--- a/app/legacy/v2/notifications/utils.py
+++ b/app/legacy/v2/notifications/utils.py
@@ -156,15 +156,15 @@ async def create_notification(
     """
     try:
         await LegacyNotificationDao.create_notification(
-            id,
-            request.get_channel(),
-            request.get_direct_contact_info(),
-            await request.get_reply_to_text(),
-            context['service_id'],
-            context['api_key_id'],
-            request.reference,
-            template_row.id,
-            template_row.version,
+            id=id,
+            notification_type=request.get_channel(),
+            to=request.get_direct_contact_info(),
+            reply_to_text=await request.get_reply_to_text(),
+            service_id=context['service_id'],
+            api_key_id=context['api_key_id'],
+            reference=request.reference,
+            template_id=template_row.id,
+            template_version=template_row.version,
         )
     except NonRetryableError as e:
         logger.exception('Failed to create notification due to unexpected error in the database')

--- a/app/legacy/v2/notifications/utils.py
+++ b/app/legacy/v2/notifications/utils.py
@@ -162,6 +162,7 @@ async def create_notification(
             await request.get_reply_to_text(),
             context['service_id'],
             context['api_key_id'],
+            request.reference,
             template_row.id,
             template_row.version,
         )

--- a/app/main.py
+++ b/app/main.py
@@ -116,5 +116,5 @@ async def get_legacy_notification(notification_id: UUID4) -> None:
     """
     from app.legacy.dao.notifications_dao import LegacyNotificationDao
 
-    data = await LegacyNotificationDao.get_notification(notification_id)
+    data = await LegacyNotificationDao.get(notification_id)
     logger.info('Notification data: {}', data._asdict())

--- a/app/providers/provider_aws.py
+++ b/app/providers/provider_aws.py
@@ -150,8 +150,8 @@ def _handle_sns_exceptions(e: Exception, fail_message: str) -> None:
         fail_message (str): The message to log when the exception is caught
 
     Raises:
-        RetryableError: Exception that can be retried
-        NonRetryableError: Don't retry the request
+        RetryableError: If the error is retryable
+        NonRetryableError: If the error is non-retryable
 
     """
     if isinstance(e, botocore.exceptions.ClientError):

--- a/app/providers/provider_base.py
+++ b/app/providers/provider_base.py
@@ -45,7 +45,7 @@ class ProviderBase(ABC):
             model (PushModel): the parameters to pass to SNS.Client.publish
 
         Raises:
-            NonRetryableError: Don't retry the request
+            NonRetryableError: If the error is non-retryable
 
         Returns:
             str: A reference identifier for the sent notification

--- a/app/providers/provider_base.py
+++ b/app/providers/provider_base.py
@@ -2,11 +2,11 @@
 
 from abc import ABC
 
-from loguru import logger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_full_jitter
 
 from app.constants import MAX_RETRIES
 from app.exceptions import NonRetryableError, RetryableError
+from app.logging.logging_config import logger
 from app.providers.provider_schemas import PushModel
 from app.utils import log_last_attempt_on_failure, log_on_retry
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,8 @@
 """Utils for logging retry information."""
 
-from loguru import logger
 from tenacity import RetryCallState
+
+from app.logging.logging_config import logger
 
 
 def log_on_retry(retry_state: RetryCallState) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -217,6 +217,18 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "async-lru"
+version = "2.0.5"
+description = "Simple LRU cache for asyncio"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "async_lru-2.0.5-py3-none-any.whl", hash = "sha256:ab95404d8d2605310d345932697371a5f40def0487c03d6d0ad9138de52c9943"},
+    {file = "async_lru-2.0.5.tar.gz", hash = "sha256:481d52ccdd27275f42c43a928b4a50c3bfb2d67af4e78b170e3e0bb39c66e5bb"},
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 description = "Classes Without Boilerplate"
@@ -5406,4 +5418,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "68b1cf6e436afd79fce51835848f0a0b66945e4b84a37dc6ff12f0056b1f4ad6"
+content-hash = "1930162f4ec28618de26820881b763d40d4ba763f7d7dc36d89c1b2d220dfa41"

--- a/poetry.lock
+++ b/poetry.lock
@@ -378,6 +378,18 @@ types-awscrt = "*"
 botocore = ["botocore"]
 
 [[package]]
+name = "cachetools"
+version = "6.0.0"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "cachetools-6.0.0-py3-none-any.whl", hash = "sha256:82e73ba88f7b30228b5507dce1a1f878498fc669d972aef2dde4f3a3c24f103e"},
+    {file = "cachetools-6.0.0.tar.gz", hash = "sha256:f225782b84438f828328fc2ad74346522f27e5b1440f4e9fd18b20ebfd1aa2cf"},
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -4734,6 +4746,18 @@ files = [
 ]
 
 [[package]]
+name = "types-cachetools"
+version = "6.0.0.20250525"
+description = "Typing stubs for cachetools"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "types_cachetools-6.0.0.20250525-py3-none-any.whl", hash = "sha256:1de8f0fe4bdcb187a48d2026c1e3672830f67943ad2bf3486abe031b632f1252"},
+    {file = "types_cachetools-6.0.0.20250525.tar.gz", hash = "sha256:baf06f234cac3aeb44c07893447ba03ecdb6c0742ba2607e28a35d38e6821b02"},
+]
+
+[[package]]
 name = "types-s3transfer"
 version = "0.12.0"
 description = "Type annotations and code completion for s3transfer"
@@ -5382,4 +5406,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "4a29b4e135c9f195959fe212d2d62105395249c39a8e275654a2d0a1af990c51"
+content-hash = "68b1cf6e436afd79fce51835848f0a0b66945e4b84a37dc6ff12f0056b1f4ad6"

--- a/poetry.lock
+++ b/poetry.lock
@@ -390,18 +390,6 @@ types-awscrt = "*"
 botocore = ["botocore"]
 
 [[package]]
-name = "cachetools"
-version = "6.0.0"
-description = "Extensible memoizing collections and decorators"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "cachetools-6.0.0-py3-none-any.whl", hash = "sha256:82e73ba88f7b30228b5507dce1a1f878498fc669d972aef2dde4f3a3c24f103e"},
-    {file = "cachetools-6.0.0.tar.gz", hash = "sha256:f225782b84438f828328fc2ad74346522f27e5b1440f4e9fd18b20ebfd1aa2cf"},
-]
-
-[[package]]
 name = "certifi"
 version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -4758,18 +4746,6 @@ files = [
 ]
 
 [[package]]
-name = "types-cachetools"
-version = "6.0.0.20250525"
-description = "Typing stubs for cachetools"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "types_cachetools-6.0.0.20250525-py3-none-any.whl", hash = "sha256:1de8f0fe4bdcb187a48d2026c1e3672830f67943ad2bf3486abe031b632f1252"},
-    {file = "types_cachetools-6.0.0.20250525.tar.gz", hash = "sha256:baf06f234cac3aeb44c07893447ba03ecdb6c0742ba2607e28a35d38e6821b02"},
-]
-
-[[package]]
 name = "types-s3transfer"
 version = "0.12.0"
 description = "Type annotations and code completion for s3transfer"
@@ -5418,4 +5394,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "1930162f4ec28618de26820881b763d40d4ba763f7d7dc36d89c1b2d220dfa41"
+content-hash = "bc82f0720a00ff7e118c81cf61b7896d0155451e130e44a80a548cf345f73282"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ starlette_context = "*"
 tenacity = "*"
 types-aiobotocore = {extras = ["essential"], version = "*"}
 uvicorn-worker = "*"
+cachetools = "^6.0.0"
+types-cachetools = "^6.0.0.20250525"
 
 [tool.poetry.group.test]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ types-aiobotocore = {extras = ["essential"], version = "*"}
 uvicorn-worker = "*"
 cachetools = "^6.0.0"
 types-cachetools = "^6.0.0.20250525"
+async-lru = "^2.0.5"
 
 [tool.poetry.group.test]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ starlette_context = "*"
 tenacity = "*"
 types-aiobotocore = {extras = ["essential"], version = "*"}
 uvicorn-worker = "*"
-cachetools = "^6.0.0"
-types-cachetools = "^6.0.0.20250525"
-async-lru = "^2.0.5"
+async-lru = "*"
 
 [tool.poetry.group.test]
 optional = true

--- a/tests/app/legacy/dao/test_api_keys.py
+++ b/tests/app/legacy/dao/test_api_keys.py
@@ -51,13 +51,13 @@ class TestLegacyApiKeysDao:
         """Test that API keys can be retrieved by service ID.
 
         Given a committed API key associated with a sample service (via the prepared_api_key fixture),
-        this test verifies that LegacyApiKeysDao.get_api_keys correctly returns the expected key.
+        this test verifies that LegacyApiKeysDao.get_service_api_keys correctly returns the expected key.
 
         Asserts:
             - Exactly one API key is returned for the service
             - The returned key's ID and name match the inserted key
         """
-        keys = await LegacyApiKeysDao.get_api_keys(prepared_api_key.service_id)
+        keys = await LegacyApiKeysDao.get_service_api_keys(prepared_api_key.service_id)
 
         assert len(keys) == 1, 'prepared service should only have one api key'
 
@@ -70,7 +70,7 @@ class TestLegacyApiKeysDao:
 
     async def test_get_api_keys_should_return_empty_list(self) -> None:
         """API keys should not exist for non-existant service."""
-        keys = await LegacyApiKeysDao.get_api_keys(uuid4())
+        keys = await LegacyApiKeysDao.get_service_api_keys(uuid4())
 
         assert len(keys) == 0, 'keys should not exist'
 
@@ -99,7 +99,7 @@ class TestLegacyApiKeysDao:
             mock_session_ctx.return_value.__aenter__.return_value = mock_session
 
             with pytest.raises(expected_error):
-                await LegacyApiKeysDao.get_api_keys(service_id)
+                await LegacyApiKeysDao._get_api_keys_for_service(service_id)
 
 
 class TestApiKeyRecord:

--- a/tests/app/legacy/dao/test_services.py
+++ b/tests/app/legacy/dao/test_services.py
@@ -37,7 +37,7 @@ class TestLegacyServiceDao:
         Asserts:
             - The retrieved service ID matches the inserted service ID.
         """
-        service = await LegacyServiceDao.get_service(prepared_service.id)
+        service = await LegacyServiceDao.get(prepared_service.id)
 
         for column in prepared_service._mapping.keys():
             expected = prepared_service._mapping[column]
@@ -47,7 +47,7 @@ class TestLegacyServiceDao:
     async def test_get_service_raises_if_not_found(self) -> None:
         """Should raise NoResultFound when service does not exist in DB."""
         with pytest.raises(NonRetryableError):
-            await LegacyServiceDao.get_service(uuid4())
+            await LegacyServiceDao.get(uuid4())
 
     @pytest.mark.parametrize(
         ('raised_exception', 'expected_error'),
@@ -76,4 +76,4 @@ class TestLegacyServiceDao:
             mock_session_ctx.return_value.__aenter__.return_value = mock_session
 
             with pytest.raises(expected_error):
-                await LegacyServiceDao.get_service(service_id)
+                await LegacyServiceDao._get(service_id)

--- a/tests/app/legacy/v2/notifications/test_auth.py
+++ b/tests/app/legacy/v2/notifications/test_auth.py
@@ -258,9 +258,9 @@ class TestValidateServiceApiKey:
             _validate_service_api_key(api_key, str(api_key.service_id), service_name)
 
             mock_warning.assert_called_once_with(
-                'service {} - {} used old-style api key {} with no expiry_date',
-                str(api_key.service_id),
+                '({}) service {} - used old-style api key {} with no expiry_date',
                 service_name,
+                str(api_key.service_id),
                 api_key.id,
             )
 
@@ -274,9 +274,9 @@ class TestValidateServiceApiKey:
             _validate_service_api_key(api_key, str(api_key.service_id), service_name)
 
             mock_warning.assert_called_once_with(
-                'service {} - {} used expired api key {} expired as of {}',
-                str(api_key.service_id),
+                '({}) service {} - used expired api key {} expired as of {}',
                 service_name,
+                str(api_key.service_id),
                 api_key.id,
                 api_key.expiry_date,
             )

--- a/tests/app/legacy/v2/notifications/test_rest.py
+++ b/tests/app/legacy/v2/notifications/test_rest.py
@@ -345,7 +345,7 @@ class TestSmsPostHandler:
             assert response.status_code == status.HTTP_201_CREATED
 
             # Validate the passed-in sms_sender_id was used
-            notification = await LegacyNotificationDao.get_notification(resp_json['id'])
+            notification = await LegacyNotificationDao.get(resp_json['id'])
             assert notification.reply_to_text == db_data['service_sms_sender'].sms_sender
         finally:
             await LegacyNotificationDao.delete_notification(resp_json['id'])
@@ -368,7 +368,7 @@ class TestSmsPostHandler:
             assert response.status_code == status.HTTP_201_CREATED
 
             # Validate the correct sms sender was used
-            notification = await LegacyNotificationDao.get_notification(resp_json['id'])
+            notification = await LegacyNotificationDao.get(resp_json['id'])
             service_sms_sender = await LegacyServiceSmsSenderDao.get_service_default(db_data['service'].id)
             assert notification.reply_to_text == service_sms_sender.sms_sender
         finally:

--- a/tests/app/legacy/v2/notifications/test_rest.py
+++ b/tests/app/legacy/v2/notifications/test_rest.py
@@ -14,6 +14,7 @@ from sqlalchemy import Row, delete
 from app.constants import IdentifierType, MobileAppType
 from app.db.db_init import get_write_session_with_context, metadata_legacy
 from app.legacy.dao.notifications_dao import LegacyNotificationDao
+from app.legacy.dao.service_sms_sender_dao import LegacyServiceSmsSenderDao
 from app.legacy.v2.notifications.resolvers import (
     DirectSmsTaskResolver,
     IdentifierSmsTaskResolver,
@@ -22,7 +23,6 @@ from app.legacy.v2.notifications.rest import _sms_post
 from app.legacy.v2.notifications.route_schema import (
     PersonalisationFileObject,
     RecipientIdentifierModel,
-    V2PostNotificationRequestModel,
     V2PostPushRequestModel,
     V2PostPushResponseModel,
     V2PostSmsRequestModel,
@@ -112,6 +112,7 @@ class TestSmsPostHandler:
         self,
         sample_api_key: Callable[..., Awaitable[Row[Any]]],
         sample_service: Callable[..., Awaitable[Row[Any]]],
+        sample_service_sms_sender: Callable[..., Awaitable[Row[Any]]],
         sample_template: Callable[..., Awaitable[Row[Any]]],
         sample_user: Callable[..., Awaitable[Row[Any]]],
     ) -> AsyncGenerator[Callable[[], Coroutine[Any, Any, dict[str, Row[Any]]]], None]:
@@ -120,6 +121,7 @@ class TestSmsPostHandler:
         Args:
             sample_api_key (Callable[..., Awaitable[Row[Any]]]): ApiKey
             sample_service (Callable[..., Awaitable[Row[Any]]]): Service
+            sample_service_sms_sender (Callable[..., Awaitable[Row[Any]]]): ServiceSmsSender
             sample_template (Callable[..., Awaitable[Row[Any]]]): Template
             sample_user (Callable[..., Awaitable[Row[Any]]]): User
 
@@ -133,6 +135,8 @@ class TestSmsPostHandler:
             async with get_write_session_with_context() as session:
                 user = await sample_user(session)
                 service = await sample_service(session, created_by_id=user.id)
+                await sample_service_sms_sender(service.id, session, is_default=True)  # Service default, bury it
+                service_sms_sender = await sample_service_sms_sender(service.id, session, is_default=False)
                 template = await sample_template(session, service_id=service.id, created_by_id=user.id)
                 api_key = await sample_api_key(session, service_id=service.id)
                 await session.commit()
@@ -140,18 +144,30 @@ class TestSmsPostHandler:
             ids['service'] = service.id
             ids['template'] = template.id
             ids['api_key'] = api_key.id
-            return {'user': user, 'service': service, 'template': template, 'api_key': api_key}
+            return {
+                'user': user,
+                'service': service,
+                'template': template,
+                'api_key': api_key,
+                'service_sms_sender': service_sms_sender,
+            }
 
         yield _wrapper
 
         # Teardown
         legacy_api_keys = metadata_legacy.tables['api_keys']
         legacy_services = metadata_legacy.tables['services']
+        legacy_service_sms_senders = metadata_legacy.tables['service_sms_senders']
         legacy_templates = metadata_legacy.tables['templates']
         legacy_templates_hist = metadata_legacy.tables['templates_history']
         legacy_users = metadata_legacy.tables['users']
 
         async with get_write_session_with_context() as session:
+            # delete both service_sms_sender entries - Uses the service_id to delete instead of it's id
+            sender_delete_stmt = delete(legacy_service_sms_senders).where(
+                legacy_service_sms_senders.c.service_id == ids['service']
+            )
+            await session.execute(sender_delete_stmt)
             # delete the template history
             th_delete_stmt = delete(legacy_templates_hist).where(legacy_templates_hist.c.id == ids['template'])
             await session.execute(th_delete_stmt)
@@ -224,24 +240,23 @@ class TestSmsPostHandler:
             | None = None,
         ) -> dict[str, object]:
             # Default to the simplest. Template requires personalization
-            request_data: V2PostSmsRequestModel | V2PostNotificationRequestModel
+            request_data: V2PostSmsRequestModel
             if phone_number:
                 request_data = V2PostSmsRequestModel(
                     phone_number=ValidatedPhoneNumber(phone_number),
                     template_id=template_id,
-                    personalisation=personalization or {'verify_code': '12345'},
+                    personalisation=personalization,
                 )
             else:
-                request_data = V2PostNotificationRequestModel(
+                request_data = V2PostSmsRequestModel(
                     recipient_identifier=recipient_identifier,
                     template_id=template_id,
-                    personalisation=personalization or {'verify_code': '12345'},
+                    personalisation=personalization,
                 )
             if reference is not None:
                 request_data.reference = reference
-            # TODO: 272 - Add sms_sender_id here
-            # if sms_sender_id is not None:
-            #     request_data.sms_sender_id = sms_sender_id
+            if sms_sender_id is not None:
+                request_data.sms_sender_id = sms_sender_id
             data: dict[str, object] = jsonable_encoder(request_data)
             return data
 
@@ -305,6 +320,57 @@ class TestSmsPostHandler:
             assert response.status_code == status.HTTP_201_CREATED
             resp_json = response.json()
             assert resp_json['reference'] == reference if reference is not None else 'null'
+        finally:
+            await LegacyNotificationDao.delete_notification(resp_json['id'])
+
+    async def test_sms_sender_id_in_request(
+        self,
+        mock_background_task: AsyncMock,
+        client: ENPTestClient,
+        prepare_database: Callable[[], Coroutine[Any, Any, dict[str, Row[Any]]]],
+        path_request: Callable[..., dict[str, object]],
+        build_headers: Callable[[UUID, UUID], dict[str, str]],
+    ) -> None:
+        """Test sms notification route returns 201 with valid template."""
+        db_data = await prepare_database()
+        request = path_request(
+            template_id=db_data['template'].id,
+            phone_number='+18005550101',
+            sms_sender_id=db_data['service_sms_sender'].id,
+        )
+        headers = build_headers(db_data['api_key'].id, db_data['service'].id)
+        try:
+            response = client.post(self.sms_route, json=request, headers=headers)
+            resp_json = response.json()
+            assert response.status_code == status.HTTP_201_CREATED
+
+            # Validate the passed-in sms_sender_id was used
+            notification = await LegacyNotificationDao.get_notification(resp_json['id'])
+            assert notification.reply_to_text == db_data['service_sms_sender'].sms_sender
+        finally:
+            await LegacyNotificationDao.delete_notification(resp_json['id'])
+
+    async def test_sms_sender_id_default(
+        self,
+        mock_background_task: AsyncMock,
+        client: ENPTestClient,
+        prepare_database: Callable[[], Coroutine[Any, Any, dict[str, Row[Any]]]],
+        path_request: Callable[..., dict[str, object]],
+        build_headers: Callable[[UUID, UUID], dict[str, str]],
+    ) -> None:
+        """Test sms notification route returns 201 with valid template."""
+        db_data = await prepare_database()
+        request = path_request(template_id=db_data['template'].id, phone_number='+18005550101')
+        headers = build_headers(db_data['api_key'].id, db_data['service'].id)
+        try:
+            response = client.post(self.sms_route, json=request, headers=headers)
+            resp_json = response.json()
+            assert response.status_code == status.HTTP_201_CREATED
+
+            # Validate the correct sms sender was used
+            notification = await LegacyNotificationDao.get_notification(resp_json['id'])
+            service_sms_sender = await LegacyServiceSmsSenderDao.get_service_default(db_data['service'].id)
+            assert notification.reply_to_text == service_sms_sender.sms_sender
         finally:
             await LegacyNotificationDao.delete_notification(resp_json['id'])
 

--- a/tests/app/legacy/v2/notifications/test_route_schema.py
+++ b/tests/app/legacy/v2/notifications/test_route_schema.py
@@ -150,7 +150,7 @@ class TestV2PostEmailRequestModel:
             mocker (AsyncMock): Mock object
         """
         mocker.patch(
-            'app.legacy.v2.notifications.route_schema.LegacyTemplateDao.get_template',
+            'app.legacy.v2.notifications.route_schema.LegacyTemplateDao.get',
             return_value=mocker.AsyncMock(),
             new_callable=AsyncMock,
         )
@@ -270,9 +270,7 @@ class TestV2PostNotificationRequestModel:
         Args:
             mocker (AsyncMock): Mock object
         """
-        mocker.patch(
-            'app.legacy.v2.notifications.route_schema.LegacyTemplateDao.get_template', return_value=mocker.AsyncMock()
-        )
+        mocker.patch('app.legacy.v2.notifications.route_schema.LegacyTemplateDao.get', return_value=mocker.AsyncMock())
         recipient = RecipientIdentifierModel(id_type=IdentifierType.VA_PROFILE_ID, id_value='12345')
         model = V2PostNotificationRequestModel(recipient_identifier=recipient, template_id=uuid4())
         with pytest.raises(NotImplementedError):

--- a/tests/app/legacy/v2/notifications/test_route_schema.py
+++ b/tests/app/legacy/v2/notifications/test_route_schema.py
@@ -3,13 +3,17 @@
 The tests cover Pydantic models that have custom validation.
 """
 
+from typing import Any, Awaitable, Callable
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException, status
 from pydantic import ValidationError
+from sqlalchemy import Row
 
 from app.constants import IdentifierType, NotificationType
+from app.exceptions import NonRetryableError
 from app.legacy.v2.notifications.route_schema import (
     RecipientIdentifierModel,
     V2PostEmailRequestModel,
@@ -146,7 +150,9 @@ class TestV2PostEmailRequestModel:
             mocker (AsyncMock): Mock object
         """
         mocker.patch(
-            'app.legacy.v2.notifications.route_schema.LegacyTemplateDao.get_template', return_value=mocker.AsyncMock()
+            'app.legacy.v2.notifications.route_schema.LegacyTemplateDao.get_template',
+            return_value=mocker.AsyncMock(),
+            new_callable=AsyncMock,
         )
         model = V2PostEmailRequestModel(email_address='fake_email@va.gov', template_id=uuid4())
         assert isinstance(await model.get_reply_to_text(), str)
@@ -170,17 +176,73 @@ class TestV2PostSmsRequestModel:
         """Test V2PostSmsRequestModel instantiation works."""
         V2PostSmsRequestModel(phone_number='+18005550101', template_id=uuid4())
 
-    async def test_get_reply_to(self, mocker: AsyncMock) -> None:
-        """Test get_reply_to_tex returns a string.
+    async def test_get_reply_to_with_sender(
+        self,
+        sample_service: Callable[..., Awaitable[Row[Any]]],
+        sample_service_sms_sender: Callable[..., Awaitable[Row[Any]]],
+        mocker: AsyncMock,
+    ) -> None:
+        """Test get_reply_to_text returns the correct sms_sender.
+
+        Args:
+            sample_service (Callable[..., Awaitable[Row[Any]]]): Service
+            sample_service_sms_sender (Callable[..., Awaitable[Row[Any]]]): ServiceSmsSender
+            mocker (AsyncMock): Mock object
+        """
+        service_sms_sender = await sample_service_sms_sender((await sample_service()).id)
+        mocker.patch(
+            'app.legacy.v2.notifications.route_schema.LegacyServiceSmsSenderDao.get', return_value=service_sms_sender
+        )
+        mocker.patch('app.legacy.v2.notifications.route_schema.context')
+        model = V2PostSmsRequestModel(
+            phone_number='+18005550101', template_id=uuid4(), sms_sender_id=service_sms_sender.id
+        )
+        assert (await model.get_reply_to_text()) == service_sms_sender.sms_sender
+
+    async def test_get_reply_to_no_sender(
+        self,
+        sample_service: Callable[..., Awaitable[Row[Any]]],
+        sample_service_sms_sender: Callable[..., Awaitable[Row[Any]]],
+        mocker: AsyncMock,
+    ) -> None:
+        """Test get_reply_to_text returns the correct sms_sender.
+
+        Args:
+            sample_service (Callable[..., Awaitable[Row[Any]]]): Service
+            sample_service_sms_sender (Callable[..., Awaitable[Row[Any]]]): ServiceSmsSender
+            mocker (AsyncMock): Mock object
+        """
+        service_sms_sender = await sample_service_sms_sender((await sample_service()).id)
+        mocker.patch(
+            'app.legacy.v2.notifications.route_schema.LegacyServiceSmsSenderDao.get_service_default',
+            return_value=service_sms_sender,
+        )
+        mocker.patch('app.legacy.v2.notifications.route_schema.context')
+        model = V2PostSmsRequestModel(phone_number='+18005550101', template_id=uuid4())
+        assert (await model.get_reply_to_text()) == service_sms_sender.sms_sender
+
+    async def test_get_reply_to_exception(self, mocker: AsyncMock) -> None:
+        """Test get_reply_to_text raises the exception correctly.
 
         Args:
             mocker (AsyncMock): Mock object
         """
+        mock_context = mocker.patch('app.legacy.v2.notifications.route_schema.context')
+        service_id = uuid4()
+        sms_sender_id = uuid4()
+        mock_context.__getitem__.return_value = service_id
         mocker.patch(
-            'app.legacy.v2.notifications.route_schema.LegacyTemplateDao.get_template', return_value=mocker.AsyncMock()
+            'app.legacy.v2.notifications.route_schema.LegacyServiceSmsSenderDao.get', side_effect=NonRetryableError
         )
-        model = V2PostSmsRequestModel(phone_number='+18005550101', template_id=uuid4())
-        assert isinstance(await model.get_reply_to_text(), str)
+
+        model = V2PostSmsRequestModel(phone_number='+18005550101', template_id=uuid4(), sms_sender_id=sms_sender_id)
+        with pytest.raises(HTTPException) as exc_info:
+            await model.get_reply_to_text()
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert (
+            exc_info.value.detail
+            == f'sms_sender_id {sms_sender_id} does not exist in database for service id {service_id}'
+        )
 
     def test_get_direct_contact_info(self) -> None:
         """Test get_direct_contact_info returns a phone number."""

--- a/tests/app/legacy/v2/notifications/test_utils.py
+++ b/tests/app/legacy/v2/notifications/test_utils.py
@@ -91,7 +91,7 @@ class TestValidateTemplate:
         """Test validate_template for happy path."""
         template = await sample_template()
 
-        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get_template', return_value=template):
+        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get', return_value=template):
             # validate_template either runs successfully or raises an exception
             await validate_template(template.id, NotificationType.SMS, None)
 
@@ -101,13 +101,13 @@ class TestValidateTemplate:
         """Test validate_template for happy path."""
         template = await sample_template(content='before ((content)) after')
 
-        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get_template', return_value=template):
+        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get', return_value=template):
             # validate_template either runs successfully or raises an exception
             await validate_template(template.id, NotificationType.SMS, {'Content': 'test content'})
 
     async def test_validate_template_raises_exception_when_template_not_found(self) -> None:
         """Test validate_template raises an exception when the template is not found."""
-        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get_template', side_effect=NoResultFound):
+        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get', side_effect=NoResultFound):
             with pytest.raises(RequestValidationError) as exc_info:
                 await validate_template(uuid4(), NotificationType.SMS, None)
             assert exc_info.value.errors()[0]['msg'] == 'Template not found'
@@ -119,7 +119,7 @@ class TestValidateTemplate:
         """Test validate_template raises an exception when the template is not found."""
         template = await sample_template(template_type=NotificationType.EMAIL)
 
-        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get_template', return_value=template):
+        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get', return_value=template):
             with pytest.raises(RequestValidationError) as exc_info:
                 await validate_template(template.id, NotificationType.SMS, None)
             assert exc_info.value.errors()[0]['msg'] == (
@@ -141,7 +141,7 @@ class TestValidateTemplate:
         """Test validate_template raises an exception when the template is not found."""
         template = await sample_template(archived=True)
 
-        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get_template', return_value=template):
+        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get', return_value=template):
             with pytest.raises(RequestValidationError) as exc_info:
                 await validate_template(template.id, NotificationType.SMS, None)
             assert exc_info.value.errors()[0]['msg'] == 'Template is not active'
@@ -158,7 +158,7 @@ class TestValidateTemplate:
         """Test validate_template raises an exception when personalisation is missing."""
         template = await sample_template(content='before ((content)) after')
 
-        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get_template', return_value=template):
+        with patch('app.legacy.v2.notifications.utils.LegacyTemplateDao.get', return_value=template):
             with pytest.raises(RequestValidationError) as exc_info:
                 await validate_template(template.id, NotificationType.SMS, {})
             assert exc_info.value.errors()[0]['msg'] == 'Missing personalisation: content'

--- a/tests/app/legacy/v2/notifications/test_utils.py
+++ b/tests/app/legacy/v2/notifications/test_utils.py
@@ -187,11 +187,14 @@ async def test_create_notification_happy_path(mocker: AsyncMock) -> None:
     Args:
         mocker (AsyncMock): Mock object
     """
-    request = V2PostSmsRequestModel(phone_number='+18005550101', template_id=uuid4())
     mocker.patch('app.legacy.v2.notifications.utils.LegacyNotificationDao.create_notification')
+    mocker.patch('app.legacy.v2.notifications.route_schema.LegacyServiceSmsSenderDao.get_service_default')
     mock_context = mocker.patch('app.legacy.v2.notifications.utils.context')
-    mock_context.api_key = uuid4()
-    mock_context.service_id = uuid4()
+    mock_context['api_key_id'] = uuid4()
+    mock_context['service_id'] = uuid4()
+    mocker.patch('app.legacy.v2.notifications.route_schema.context', return_value=mock_context)
+
+    request = V2PostSmsRequestModel(phone_number='+18005550101', template_id=uuid4())
     await create_notification(uuid4(), mocker.AsyncMock(), request)
 
 
@@ -205,9 +208,11 @@ async def test_create_notification_failure(mocker: AsyncMock) -> None:
     mocker.patch(
         'app.legacy.v2.notifications.utils.LegacyNotificationDao.create_notification', side_effect=NonRetryableError
     )
+    mocker.patch('app.legacy.v2.notifications.route_schema.LegacyServiceSmsSenderDao.get_service_default')
     mock_context = mocker.patch('app.legacy.v2.notifications.utils.context')
-    mock_context.api_key = uuid4()
-    mock_context.service_id = uuid4()
+    mock_context['api_key_id'] = uuid4()
+    mock_context['service_id'] = uuid4()
+    mocker.patch('app.legacy.v2.notifications.route_schema.context', return_value=mock_context)
 
     with pytest.raises(HTTPException) as exc_info:
         await create_notification(uuid4(), mocker.AsyncMock(), request)

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -66,11 +66,14 @@ class TestVerifyServiceToken:
             mock_context (AsyncMock): Mocked starlette context
             mocker (AsyncMock): Mock object
         """
-        mock_service = mocker.patch('app.auth.get_active_service_for_issuer')
+        # new_callable=AsyncMock to avoid the cache
+        mock_service = mocker.patch(
+            'app.auth.get_active_service_for_issuer', new_callable=AsyncMock, return_value=(uuid4(), 'service_name')
+        )
         mock_service.id = uuid4()
         mock_service.name = 'Mock Name'
         mock_api_key = mocker.patch.object(ApiKeyRecord, 'from_row')
-        mocker.patch('app.auth._get_service_api_keys', return_value=[mock_api_key])
+        mocker.patch('app.auth._get_service_api_keys', new_callable=AsyncMock, return_value=[mock_api_key])
         mocker.patch('app.auth._verify_service_token', return_value=True)
         mocker.patch('app.auth._validate_service_api_key')
 
@@ -104,12 +107,12 @@ class TestVerifyServiceToken:
             mock_context (AsyncMock): Mocked starlette context
             mocker (AsyncMock): Mock object
         """
-        # _verify_service_token never finds a key
-        mock_service = mocker.patch('app.auth.get_active_service_for_issuer')
-        mock_service.id = uuid4()
-        mock_service.name = 'Mock Name'
+        # new_callable=AsyncMock to avoid the cache
+        mock_service = mocker.patch(
+            'app.auth.get_active_service_for_issuer', new_callable=AsyncMock, return_value=(uuid4(), str(uuid4()))
+        )
         mock_api_key = mocker.patch.object(ApiKeyRecord, 'from_row')
-        mocker.patch('app.auth._get_service_api_keys', return_value=[mock_api_key])
+        mocker.patch('app.auth._get_service_api_keys', new_callable=AsyncMock, return_value=[mock_api_key])
 
         with pytest.raises(HTTPException) as exc_info:
             await verify_service_token(str(mock_service.id), 'Fake token')
@@ -147,7 +150,7 @@ class TestGetServiceApiKeys:
             mocker (AsyncMock): Mock object
         """
         mocker.patch('app.auth.LegacyApiKeysDao.get_api_keys')
-        await _get_service_api_keys(uuid4(), uuid4())
+        await _get_service_api_keys(uuid4())
 
     @pytest.mark.parametrize('test_exception', [RetryableError, NonRetryableError])
     async def test_no_api_keys(self, test_exception: Exception, mocker: AsyncMock) -> None:
@@ -159,7 +162,7 @@ class TestGetServiceApiKeys:
         """
         mocker.patch('app.auth.LegacyApiKeysDao.get_api_keys', side_effect=test_exception)
         with pytest.raises(HTTPException) as exc_info:
-            await _get_service_api_keys(uuid4(), uuid4())
+            await _get_service_api_keys(uuid4())
         assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
         assert exc_info.value.detail == RESPONSE_LEGACY_INVALID_TOKEN_NO_KEYS
 
@@ -610,7 +613,7 @@ class TestGetActiveServiceForIssuer:
         mock_service.active = True
         mock_service.id = service_id
 
-        await get_active_service_for_issuer(str(service_id), uuid4())
+        await get_active_service_for_issuer(str(service_id))
 
     @pytest.mark.parametrize('test_exception', [RetryableError, NonRetryableError])
     async def test_service_lookup_failure(self, test_exception: Exception, mocker: AsyncMock) -> None:
@@ -623,7 +626,7 @@ class TestGetActiveServiceForIssuer:
         service_id = uuid4()
         mocker.patch('app.auth.LegacyServiceDao.get_service', side_effect=test_exception)
         with pytest.raises(HTTPException) as exc_info:
-            await get_active_service_for_issuer(str(service_id), uuid4())
+            await get_active_service_for_issuer(str(service_id))
         assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
         assert exc_info.value.detail == RESPONSE_LEGACY_INVALID_TOKEN_NO_SERVICE
 
@@ -639,13 +642,13 @@ class TestGetActiveServiceForIssuer:
         mock_service.id = service_id
         mocker.patch('app.auth.LegacyServiceDao.get_service', return_value=mock_service)
         with pytest.raises(HTTPException) as exc_info:
-            await get_active_service_for_issuer(str(service_id), uuid4())
+            await get_active_service_for_issuer(str(service_id))
         assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
         assert exc_info.value.detail == RESPONSE_LEGACY_INVALID_TOKEN_ARCHIVED_SERVICE
 
     async def test_invalid_uuid_for_issuer(self) -> None:
         """Test for an invalid issuer."""
         with pytest.raises(HTTPException) as exc_info:
-            await get_active_service_for_issuer('not a uuid', uuid4())
+            await get_active_service_for_issuer('not a uuid')
         assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
         assert exc_info.value.detail == RESPONSE_LEGACY_INVALID_TOKEN_WRONG_TYPE

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -149,7 +149,7 @@ class TestGetServiceApiKeys:
         Args:
             mocker (AsyncMock): Mock object
         """
-        mocker.patch('app.auth.LegacyApiKeysDao.get_api_keys')
+        mocker.patch('app.auth.LegacyApiKeysDao.get_service_api_keys', new_callable=AsyncMock)
         await _get_service_api_keys(uuid4())
 
     @pytest.mark.parametrize('test_exception', [RetryableError, NonRetryableError])
@@ -160,7 +160,7 @@ class TestGetServiceApiKeys:
             test_exception (Exception): Exception to raise
             mocker (AsyncMock): Mock object
         """
-        mocker.patch('app.auth.LegacyApiKeysDao.get_api_keys', side_effect=test_exception)
+        mocker.patch('app.auth.LegacyApiKeysDao.get_service_api_keys', side_effect=test_exception)
         with pytest.raises(HTTPException) as exc_info:
             await _get_service_api_keys(uuid4())
         assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
@@ -609,7 +609,7 @@ class TestGetActiveServiceForIssuer:
             mocker (AsyncMock): Mock object
         """
         service_id = uuid4()
-        mock_service = mocker.patch('app.auth.LegacyServiceDao.get_service')
+        mock_service = mocker.patch('app.auth.LegacyServiceDao.get', new_callable=AsyncMock)
         mock_service.active = True
         mock_service.id = service_id
 
@@ -624,7 +624,7 @@ class TestGetActiveServiceForIssuer:
             mocker (AsyncMock): Mock object
         """
         service_id = uuid4()
-        mocker.patch('app.auth.LegacyServiceDao.get_service', side_effect=test_exception)
+        mocker.patch('app.auth.LegacyServiceDao.get', side_effect=test_exception)
         with pytest.raises(HTTPException) as exc_info:
             await get_active_service_for_issuer(str(service_id))
         assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
@@ -640,7 +640,7 @@ class TestGetActiveServiceForIssuer:
         mock_service = mocker.AsyncMock()
         mock_service.active = False
         mock_service.id = service_id
-        mocker.patch('app.auth.LegacyServiceDao.get_service', return_value=mock_service)
+        mocker.patch('app.auth.LegacyServiceDao.get', return_value=mock_service, new_callable=AsyncMock)
         with pytest.raises(HTTPException) as exc_info:
             await get_active_service_for_issuer(str(service_id))
         assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Added:
- sms_sender_id capability in the request
- use the service default sms_sender_id if no sms_sender_id is provided in the request
- caching
- Removal and tweaking of some logs

issue #272 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
Deployed, tested against both cases (sender in request and not), works.

### Local testing
Local testing is functional. 

Steps: 
1. Set up your auth (pick the va notify service, make a key, save key to the service-api-key variable, etc.)
2. Insert a new service_sms_sender (see below)
3. Make a request with the new `sms_sender_id` in your request
4. View notifications table for the `reply_to_text` you expect
5. Remove `sms_sender_id` in your request and send it
6. View there is a different `reply_to_text` in the notifications table


You can add a service_sms_sender
```sql
INSERT INTO service_sms_senders (id, sms_sender, service_id, is_default, created_at) 
VALUES (
    '710e7ff5-117d-4707-9cb7-0a335bc253a6',
    'sms sender in request',
    'd6aa2c68-a2d9-4437-ab19-3ae8eb202553',
    'f',
    NOW()
);
```

That will put a new SMS sender on the VA Notify service which has the default value set to false. You can then use that id: `710e7ff5-117d-4707-9cb7-0a335bc253a6` as the `sms_sender_id` in your local request. Query the notification table for `reply_to_text` it should show an entry for `sms sender in request`. Remove the `sms_sender_id` from the request and you should see a `reply_to_text` in the `notifications` table that says `GOVUK`, which is the service default.


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
