### PR TITLE
#280 Add unit test coverage for LegacyTemplateDao

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ omit = [
     "app/legacy/dao/notifications_dao.py",
     "app/legacy/dao/recipient_identifiers_dao.py",
     "app/legacy/dao/service_sms_sender_dao.py",
-    "app/legacy/dao/templates_dao.py",
     "app/legacy/dao/utils.py",
 ]
 

--- a/tests/app/legacy/dao/conftest.py
+++ b/tests/app/legacy/dao/conftest.py
@@ -52,49 +52,45 @@ async def commit_service(
 
 @pytest.fixture
 async def commit_template(
-    sample_service: Callable[[async_scoped_session[AsyncSession]], Awaitable[Row[Any]]],
+    commit_service: Row[Any],
     sample_template: Callable[..., Awaitable[Row[Any]]],
 ) -> AsyncGenerator[Row[Any], None]:
-    """Fixture that creates, commits, and yields a sample tempalte row for integration tests.
+    """Fixture that creates, commits, and yields a sample template row for integration tests.
 
-    This fixture is intended for DAO-level tests that require a fully persisted tempalte row.
-    It ensures that the tempalte and its related user are committed to the database and then
-    cleans up both records after the test to preserve database isolation.
+    This fixture is intended for DAO-level tests that require a fully persisted template row.
+    It ensures that the template and its related user/service are committed to the database,
+    and then cleans up both template records after the test to preserve database isolation.
 
     Setup:
-        - Invokes the `sample_service` factory to create a service and its related user.
+        - Uses `commit_service` to provide a committed service and user.
         - Invokes the `sample_template` factory to create a template and template history.
-        - Commits the service and tempalte to the database so it is queryable in test logic.
+        - Commits the template to the database so it is queryable in test logic.
 
     Teardown:
-        - Deletes the template, service, and user from the legacy schema after the test completes.
+        - Deletes the template and its history from the legacy schema after the test completes.
+        - The committed service and user are cleaned up by the `commit_service` fixture.
 
     Args:
-        sample_service (Callable): A coroutine factory that creates and returns a service row.
-        sample_template (Callable): A coroutine factory that creates and returns a template row.
+        commit_service (Row[Any]): A committed service row with associated user data.
+        sample_template (Callable[..., Awaitable[Row[Any]]]): A coroutine factory that creates a template row.
 
     Yields:
         Row[Any]: A SQLAlchemy Core row representing the inserted template.
     """
     # setup
     async with get_write_session_with_context() as session:
-        service = await sample_service(session)
-        template = await sample_template(session=session, service_id=service.id)
+        template = await sample_template(session=session, service_id=commit_service.id)
         await session.commit()
 
     yield template
 
     # teardown
-    legacy_users = metadata_legacy.tables['users']
-    legacy_services = metadata_legacy.tables['services']
     legacy_templates = metadata_legacy.tables['templates']
     legacy_templates_hist = metadata_legacy.tables['templates_history']
 
     async with get_write_session_with_context() as session:
         await session.execute(delete(legacy_templates_hist).where(legacy_templates_hist.c.id == template.id))
         await session.execute(delete(legacy_templates).where(legacy_templates.c.id == template.id))
-        await session.execute(delete(legacy_services).where(legacy_services.c.id == service.id))
-        await session.execute(delete(legacy_users).where(legacy_users.c.id == service.created_by_id))
         await session.commit()
 
 

--- a/tests/app/legacy/dao/test_templates.py
+++ b/tests/app/legacy/dao/test_templates.py
@@ -1,0 +1,128 @@
+"""Tests for templates DAO methods."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import Row
+from sqlalchemy.exc import (
+    DataError,
+    InterfaceError,
+    MultipleResultsFound,
+    NoResultFound,
+    OperationalError,
+    SQLAlchemyError,
+    TimeoutError,
+)
+
+from app.exceptions import NonRetryableError, RetryableError
+from app.legacy.dao.templates_dao import LegacyTemplateDao
+
+
+class TestLegacyTemplateDaoGet:
+    """Test class for LegacyTemplateDao Get by ID method."""
+
+    async def test_get_happy_path(self, commit_template: Row[Any]) -> None:
+        """Test the ability to get a template from the database.
+
+        Args:
+            commit_template (Row[Any]): Template that was commit to the database
+        """
+        template_row = await LegacyTemplateDao.get(commit_template.id)
+        assert template_row.id == commit_template.id
+
+    async def test_get_non_existent_template(self) -> None:
+        """Should raise NoResultFound when template does not exist in DB."""
+        with pytest.raises(NonRetryableError):
+            await LegacyTemplateDao.get(uuid4())
+
+    @pytest.mark.parametrize(
+        ('caught_exception', 'raised_exception'),
+        [
+            (NoResultFound(), NonRetryableError),
+            (MultipleResultsFound(), NonRetryableError),
+            (DataError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (OperationalError('stmt', 'params', Exception('orig')), RetryableError),
+            (InterfaceError('stmt', 'params', Exception('orig')), RetryableError),
+            (TimeoutError(), RetryableError),
+            (SQLAlchemyError('some generic error'), NonRetryableError),
+        ],
+    )
+    async def test_get_exception_handling(
+        self,
+        caught_exception: Exception,
+        raised_exception: type[Exception],
+    ) -> None:
+        """Test that _get raises the correct custom error when a specific SQLAlchemy exception occurs.
+
+        Args:
+            caught_exception (Exception): The exception our code caught
+            raised_exception (type[Exception]): The exception our code raised
+        """
+        template_id = uuid4()
+
+        # Patch the session context and simulate the exception during execution
+        with patch('app.legacy.dao.templates_dao.get_read_session_with_context') as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session.execute.side_effect = caught_exception
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+
+            with pytest.raises(raised_exception):
+                await LegacyTemplateDao._get(template_id)
+
+
+class TestLegacyTemplateDaoGetByIdAndServiceId:
+    """Test class for LegacyTemplateDao methods."""
+
+    async def test_get_happy_path(self, commit_template: Row[Any]) -> None:
+        """Test the ability to get a template from the database.
+
+        Args:
+            commit_template (Row[Any]): Template that was commit to the database
+        """
+        template_row = await LegacyTemplateDao.get_by_id_and_service_id(commit_template.id, commit_template.service_id)
+        assert template_row.id == commit_template.id
+
+    async def test_get_non_existent_template(self) -> None:
+        """Should raise NoResultFound when template does not exist in DB."""
+        template_id = uuid4()
+        service_id = uuid4()
+
+        with pytest.raises(NonRetryableError):
+            await LegacyTemplateDao.get_by_id_and_service_id(template_id, service_id)
+
+    @pytest.mark.parametrize(
+        ('caught_exception', 'raised_exception'),
+        [
+            (NoResultFound(), NonRetryableError),
+            (MultipleResultsFound(), NonRetryableError),
+            (DataError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (OperationalError('stmt', 'params', Exception('orig')), RetryableError),
+            (InterfaceError('stmt', 'params', Exception('orig')), RetryableError),
+            (TimeoutError(), RetryableError),
+            (SQLAlchemyError('some generic error'), NonRetryableError),
+        ],
+    )
+    async def test_get_exception_handling(
+        self,
+        caught_exception: Exception,
+        raised_exception: type[Exception],
+    ) -> None:
+        """Test that _get raises the correct custom error when a specific SQLAlchemy exception occurs.
+
+        Args:
+            caught_exception (Exception): The exception our code caught
+            raised_exception (type[Exception]): The exception our code raised
+        """
+        template_id = uuid4()
+        service_id = uuid4()
+
+        # Patch the session context and simulate the exception during execution
+        with patch('app.legacy.dao.templates_dao.get_read_session_with_context') as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session.execute.side_effect = caught_exception
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+
+            with pytest.raises(raised_exception):
+                await LegacyTemplateDao._get_by_id_and_service_id(template_id, service_id)

--- a/tests/app/legacy/dao/test_templates.py
+++ b/tests/app/legacy/dao/test_templates.py
@@ -21,13 +21,13 @@ from app.legacy.dao.templates_dao import LegacyTemplateDao
 
 
 class TestLegacyTemplateDaoGet:
-    """Test class for LegacyTemplateDao Get by ID method."""
+    """Test class for LegacyTemplateDao.get (by ID) method."""
 
     async def test_get_happy_path(self, commit_template: Row[Any]) -> None:
         """Test the ability to get a template from the database.
 
         Args:
-            commit_template (Row[Any]): Template that was commit to the database
+            commit_template (Row[Any]): Template that was committed to the database
         """
         template_row = await LegacyTemplateDao.get(commit_template.id)
         assert template_row.id == commit_template.id
@@ -73,13 +73,13 @@ class TestLegacyTemplateDaoGet:
 
 
 class TestLegacyTemplateDaoGetByIdAndServiceId:
-    """Test class for LegacyTemplateDao methods."""
+    """Test class for LegacyTemplateDao.get_by_id_and_service_id method."""
 
     async def test_get_happy_path(self, commit_template: Row[Any]) -> None:
         """Test the ability to get a template from the database.
 
         Args:
-            commit_template (Row[Any]): Template that was commit to the database
+            commit_template (Row[Any]): Template that was committed to the database
         """
         template_row = await LegacyTemplateDao.get_by_id_and_service_id(commit_template.id, commit_template.service_id)
         assert template_row.id == commit_template.id
@@ -91,6 +91,13 @@ class TestLegacyTemplateDaoGetByIdAndServiceId:
 
         with pytest.raises(NonRetryableError):
             await LegacyTemplateDao.get_by_id_and_service_id(template_id, service_id)
+
+    async def test_get_non_existent_template_service_id(self, commit_template: Row[Any]) -> None:
+        """Should raise NoResultFound when template with correct service id does not exist in DB."""
+        service_id = uuid4()
+
+        with pytest.raises(NonRetryableError):
+            await LegacyTemplateDao.get_by_id_and_service_id(commit_template.id, service_id)
 
     @pytest.mark.parametrize(
         ('caught_exception', 'raised_exception'),


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue #280

- Removes LegacyTemplateDao from the pytest coverage omit list
- Adds a commit_template fixture to add a committed template to the db with proper cleanup
- Adds full test coverage for LegacyTemplateDao

**This PR is only making changes to unit testing**

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Local unit testing in isolation for coverage and in full to ensure all tests pass.

### Run in isolation `poetry run pytest tests/app/legacy/dao/test_templates.py`

![image](https://github.com/user-attachments/assets/ca136c79-a8a1-4aa5-bc44-ee96286856d8)

### Full battery of unit tests

![image](https://github.com/user-attachments/assets/42c9b06a-b88f-4ca8-97ff-6b85261ea6e4)

### GHA unit tests passing

Required test coverage of 100.0% reached. Total coverage: 100.00%
============================= 418 passed in 7.65s ==============================

### Unit test changes only / no changes to live code

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
