### PR TITLE
#283 Add fixtures and unit test coverage for LegacyNotificationDao

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -58,4 +58,6 @@ fileignoreconfig:
   checksum: 578512c9b93f55717b13a7c1fed8d676de042e04d1ef7e8247097e84eb745ab8
 - filename: tests/app/legacy/clients/test_sqs.py
   checksum: 4ba66df99cb553f63d9f7f1299cf3cbafa5f8d76f0fdb55685a050854b0c2c75
+- filename: tests/app/legacy/dao/test_notifications.py
+  checksum: 0966bcea3a2fc90902eb80b80aff0bc05a1351ed6c08b444b2d73cd129fbfded
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -37,7 +37,7 @@ fileignoreconfig:
 - filename: app/constants.py
   checksum: 99d65949b954a7f3dc7fd28decf413ad488d512fed167d945ae99da097d6967f
 - filename: tests/app/legacy/conftest.py
-  checksum: 934b3750f1ece758e527f077005b53e9220f1ac075f6c2ac0362e636d663980e
+  checksum: d0e0373f23fdfcae717d6fa48d195aa679ae2a8c0c691e82514ea619bd490446
 - filename: app/legacy/dao/notifications_dao.py
   checksum: 7baa74d634ad0f8357b6c9c870ceff7d8976d116844d99798349e36cad43919d
 - filename: app/auth.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -15,7 +15,7 @@ fileignoreconfig:
 - filename: postman/enp-api.postman_collection.json
   checksum: a75beb668be832bdb38484e044987be0ace21a597fa1aa30ba837d3bfc94a0c7
 - filename: tests/app/legacy/dao/conftest.py
-  checksum: c82f4eb2f484f6465fa50bb5bbbff6152c84fe4071e3724a0d91124049a2fad9
+  checksum: 302831b4c3ed1c07d8ace36625922aeb5bdbeb2de5c0119786b6cf23ac5dc19f
 - filename: app/legacy/dao/api_keys_dao.py
   checksum: f263dd3ff80dba091d18ed8032cce1fa3f5330afd050535cdf56d68c8841b908
 - filename: tests/app/providers/__init__.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -25,11 +25,11 @@ fileignoreconfig:
 - filename: tests/conftest.py
   checksum: 44a2d6e8de7940335bb84a487d3377b5339bb99219b95aca66f368dff960d537
 - filename: tests/app/legacy/test_samples.py
-  checksum: a1ba3739af869483479432aefcae8b1152e1a28f105b69b95e8fa3e02f4c8f0d
+  checksum: b8f01af0ac1b89af71d329d048a27a7e7a8f3bd33a94fe204162eb01433b0917
 - filename: app/legacy/dao/api_key_dao.py
   checksum: 9eb496d3ae4238193baf5c5627d8d186beeda815133e9b4e1bc6e56ce57a3802
 - filename: tests/app/legacy/dao/test_api_keys.py
-  checksum: c08a73f7e31069462f1ed336e33485ee9ef4bdae9ff70d0691684df361777fc7
+  checksum: 68c0b40f5a2c8ad7f993693c271aee8b11df284933c4ae945c54da565f8dcf7a
 - filename: tests/app/legacy/v2/notifications/test_auth.py
   checksum: 9a46795e0124515bc5960deee90d0a7531aaff989c39b4ecc93ab8c9f1969942
 - filename: .env.local

--- a/app/legacy/dao/notifications_dao.py
+++ b/app/legacy/dao/notifications_dao.py
@@ -19,7 +19,7 @@ from app.constants import NotificationStatus, NotificationType
 from app.db.db_init import get_read_session_with_context, get_write_session_with_context, metadata_legacy
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.utils import Serializer, db_retry
-from app.legacy.v2.notifications.route_schema import PersonalisationFileObject, RecipientIdentifierModel
+from app.legacy.v2.notifications.route_schema import PersonalisationFileObject
 from app.logging.logging_config import logger
 
 serializer = Serializer()
@@ -87,7 +87,6 @@ class LegacyNotificationDao:
         template_version: int,
         billable_units: int = 0,
         key_type: str = 'normal',
-        recipient_identifiers: RecipientIdentifierModel | None = None,
         personalisation: dict[str, str | int | float | list[str | int | float] | PersonalisationFileObject]
         | None = None,
     ) -> None:
@@ -105,7 +104,6 @@ class LegacyNotificationDao:
             template_version (int): The template version
             billable_units (int, optional): How many billable units this is. Defaults to 0.
             key_type (str, optional): ApiKey type. Defaults to 'normal'.
-            recipient_identifiers (RecipientIdentifierModel | None, optional): The recipient identifiers. Defaults to None.
             personalisation (dict[str, str | int | float | list[str | int | float] | PersonalisationFileObject] | None, optional):
                 The personalisation data for the notification. Defaults to None.
 

--- a/app/legacy/v2/notifications/utils.py
+++ b/app/legacy/v2/notifications/utils.py
@@ -176,7 +176,6 @@ async def create_notification(
             reference=request.reference,
             template_id=template_row.id,
             template_version=template_row.version,
-            recipient_identifiers=request.recipient_identifier,
             personalisation=request.personalisation,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ omit = [
     "app/main.py",
     "tests/app/test_main.py",
     "app/legacy/dao/api_keys_dao.py",
-    "app/legacy/dao/notifications_dao.py",
     "app/legacy/dao/recipient_identifiers_dao.py",
     "app/legacy/dao/utils.py",
 ]

--- a/tests/app/legacy/dao/test_api_keys.py
+++ b/tests/app/legacy/dao/test_api_keys.py
@@ -47,24 +47,24 @@ class TestLegacyApiKeysDao:
     without relying on mocks or in-memory substitutes.
     """
 
-    async def test_get_api_keys(self, prepared_api_key: Row[Any]) -> None:
+    async def test_get_api_keys(self, commit_api_key: Row[Any]) -> None:
         """Test that API keys can be retrieved by service ID.
 
-        Given a committed API key associated with a sample service (via the prepared_api_key fixture),
+        Given a committed API key associated with a sample service (via the commit_api_key fixture),
         this test verifies that LegacyApiKeysDao.get_service_api_keys correctly returns the expected key.
 
         Asserts:
             - Exactly one API key is returned for the service
             - The returned key's ID and name match the inserted key
         """
-        keys = await LegacyApiKeysDao.get_service_api_keys(prepared_api_key.service_id)
+        keys = await LegacyApiKeysDao.get_service_api_keys(commit_api_key.service_id)
 
         assert len(keys) == 1, 'prepared service should only have one api key'
 
         api_key = keys[0]
 
-        for column in prepared_api_key._mapping.keys():
-            expected = prepared_api_key._mapping[column]
+        for column in commit_api_key._mapping.keys():
+            expected = commit_api_key._mapping[column]
             actual = api_key._mapping[column]
             assert actual == expected, f'{column} mismatch: expected {expected}, got {actual}'
 

--- a/tests/app/legacy/dao/test_notifications.py
+++ b/tests/app/legacy/dao/test_notifications.py
@@ -100,6 +100,7 @@ class TestLegacyNotificationDaoCreateNotification:
 
         notification_id = uuid4()
 
+        # test
         await LegacyNotificationDao.create_notification(
             id=notification_id,
             notification_type=NotificationType.SMS,
@@ -117,6 +118,8 @@ class TestLegacyNotificationDaoCreateNotification:
 
         assert notification_row.id == notification_id
 
+        # teardown
+        # template, service, and user teardown handled by commit_template
         legacy_api_keys = metadata_legacy.tables['api_keys']
         legacy_notifications = metadata_legacy.tables['notifications']
 

--- a/tests/app/legacy/dao/test_notifications.py
+++ b/tests/app/legacy/dao/test_notifications.py
@@ -1,13 +1,15 @@
 """Tests for notifications DAO methods."""
 
-from typing import Any
+from typing import Any, Awaitable, Callable
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import delete
 from sqlalchemy.engine import Row
 from sqlalchemy.exc import (
     DataError,
+    IntegrityError,
     InterfaceError,
     MultipleResultsFound,
     NoResultFound,
@@ -16,6 +18,8 @@ from sqlalchemy.exc import (
     TimeoutError,
 )
 
+from app.constants import NotificationType
+from app.db.db_init import get_write_session_with_context, metadata_legacy
 from app.exceptions import NonRetryableError, RetryableError
 from app.legacy.dao.notifications_dao import LegacyNotificationDao
 
@@ -70,3 +74,145 @@ class TestLegacyNotificationDaoGet:
 
             with pytest.raises(raised_exception):
                 await LegacyNotificationDao._get(notification_id)
+
+
+class TestLegacyNotificationDaoCreateNotification:
+    """Test class for LegacyNotificationDao.create_notification method."""
+
+    async def test_get_happy_path(
+        self,
+        commit_template: Row[Any],
+        sample_api_key: Callable[..., Awaitable[Row[Any]]],
+    ) -> None:
+        """Test the ability to create a notification in the database.
+
+        Args:
+            commit_template (Row[Any]): Template that was committed to the database
+            sample_api_key (Callable): A factory fixture that returns a new API key row for a given service.
+        """
+        # setup
+        async with get_write_session_with_context() as session:
+            api_key = await sample_api_key(
+                session=session,
+                service_id=commit_template.service_id,
+            )
+            await session.commit()
+
+        notification_id = uuid4()
+
+        await LegacyNotificationDao.create_notification(
+            id=notification_id,
+            notification_type=NotificationType.SMS,
+            to='888-888-8888',
+            reply_to_text='111-111-1111',
+            service_id=commit_template.service_id,
+            api_key_id=api_key.id,
+            reference=str(uuid4()),
+            template_id=commit_template.id,
+            template_version=commit_template.version,
+            key_type=api_key.key_type,
+        )
+
+        notification_row = await LegacyNotificationDao.get(notification_id)
+
+        assert notification_row.id == notification_id
+
+        legacy_api_keys = metadata_legacy.tables['api_keys']
+        legacy_notifications = metadata_legacy.tables['notifications']
+
+        async with get_write_session_with_context() as session:
+            await session.execute(delete(legacy_notifications).where(legacy_notifications.c.id == notification_id))
+            await session.execute(delete(legacy_api_keys).where(legacy_api_keys.c.id == api_key.id))
+            await session.commit()
+
+    @pytest.mark.parametrize(
+        ('caught_exception', 'raised_exception'),
+        [
+            (IntegrityError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (IntegrityError('duplicate', 'params', Exception('orig')), NonRetryableError),
+            (DataError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (DataError('duplicate', 'params', Exception('orig')), NonRetryableError),
+            (OperationalError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (InterfaceError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (TimeoutError(), NonRetryableError),
+            (SQLAlchemyError('some generic error'), NonRetryableError),
+        ],
+    )
+    async def test_create_notification_exception_handling(
+        self,
+        caught_exception: Exception,
+        raised_exception: type[Exception],
+    ) -> None:
+        """Test that _insert_notification raises the correct custom error when a specific SQLAlchemy exception occurs.
+
+        Args:
+            caught_exception (Exception): The exception our code caught
+            raised_exception (type[Exception]): The exception our code raised
+        """
+        # Patch the session context and simulate the exception during execution
+        with patch('app.legacy.dao.notifications_dao.get_write_session_with_context') as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session.execute.side_effect = caught_exception
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+
+            with pytest.raises(raised_exception):
+                await LegacyNotificationDao.create_notification(
+                    id=uuid4(),
+                    notification_type=NotificationType.SMS,
+                    to='888-888-8888',
+                    reply_to_text='111-111-1111',
+                    service_id=uuid4(),
+                    api_key_id=uuid4(),
+                    reference=str(uuid4()),
+                    template_id=uuid4(),
+                    template_version=0,
+                    billable_units=0,
+                    key_type='normal',
+                    personalisation=None,
+                )
+
+    @pytest.mark.parametrize(
+        ('caught_exception', 'raised_exception'),
+        [
+            (IntegrityError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (IntegrityError('duplicate', 'params', Exception('orig')), RetryableError),
+            (DataError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (DataError('duplicate', 'params', Exception('orig')), RetryableError),
+            (OperationalError('stmt', 'params', Exception('orig')), RetryableError),
+            (InterfaceError('stmt', 'params', Exception('orig')), RetryableError),
+            (TimeoutError(), RetryableError),
+            (SQLAlchemyError('some generic error'), NonRetryableError),
+        ],
+    )
+    async def test_insert_notification_exception_handling(
+        self,
+        caught_exception: Exception,
+        raised_exception: type[Exception],
+    ) -> None:
+        """Test that _insert_notification raises the correct custom error when a specific SQLAlchemy exception occurs.
+
+        Args:
+            caught_exception (Exception): The exception our code caught
+            raised_exception (type[Exception]): The exception our code raised
+        """
+        # Patch the session context and simulate the exception during execution
+        with patch('app.legacy.dao.notifications_dao.get_write_session_with_context') as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session.execute.side_effect = caught_exception
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+
+            with pytest.raises(raised_exception):
+                await LegacyNotificationDao._insert_notification(
+                    id=uuid4(),
+                    notification_type=NotificationType.SMS,
+                    to='888-888-8888',
+                    reply_to_text='111-111-1111',
+                    service_id=uuid4(),
+                    api_key_id=uuid4(),
+                    reference=str(uuid4()),
+                    template_id=uuid4(),
+                    template_version=0,
+                    billable_units=0,
+                    key_type='normal',
+                    personalisation=None,
+                )

--- a/tests/app/legacy/dao/test_notifications.py
+++ b/tests/app/legacy/dao/test_notifications.py
@@ -1,0 +1,72 @@
+"""Tests for notifications DAO methods."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.engine import Row
+from sqlalchemy.exc import (
+    DataError,
+    InterfaceError,
+    MultipleResultsFound,
+    NoResultFound,
+    OperationalError,
+    SQLAlchemyError,
+    TimeoutError,
+)
+
+from app.exceptions import NonRetryableError, RetryableError
+from app.legacy.dao.notifications_dao import LegacyNotificationDao
+
+
+class TestLegacyNotificationDaoGet:
+    """Test class for LegacyNotificationDao.get method."""
+
+    async def test_get_happy_path(self, commit_notification: Row[Any]) -> None:
+        """Test the ability to get a notification from the database.
+
+        Args:
+            commit_notification (Row[Any]): Notification that was committed to the database
+        """
+        notification_row = await LegacyNotificationDao.get(commit_notification.id)
+        assert notification_row.id == commit_notification.id
+
+    async def test_get_non_existent_notification(self) -> None:
+        """Should raise NoResultFound when notification does not exist in DB."""
+        with pytest.raises(NonRetryableError):
+            await LegacyNotificationDao.get(uuid4())
+
+    @pytest.mark.parametrize(
+        ('caught_exception', 'raised_exception'),
+        [
+            (NoResultFound(), NonRetryableError),
+            (MultipleResultsFound(), NonRetryableError),
+            (DataError('stmt', 'params', Exception('orig')), NonRetryableError),
+            (OperationalError('stmt', 'params', Exception('orig')), RetryableError),
+            (InterfaceError('stmt', 'params', Exception('orig')), RetryableError),
+            (TimeoutError(), RetryableError),
+            (SQLAlchemyError('some generic error'), NonRetryableError),
+        ],
+    )
+    async def test_get_exception_handling(
+        self,
+        caught_exception: Exception,
+        raised_exception: type[Exception],
+    ) -> None:
+        """Test that _get raises the correct custom error when a specific SQLAlchemy exception occurs.
+
+        Args:
+            caught_exception (Exception): The exception our code caught
+            raised_exception (type[Exception]): The exception our code raised
+        """
+        notification_id = uuid4()
+
+        # Patch the session context and simulate the exception during execution
+        with patch('app.legacy.dao.notifications_dao.get_read_session_with_context') as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session.execute.side_effect = caught_exception
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+
+            with pytest.raises(raised_exception):
+                await LegacyNotificationDao._get(notification_id)

--- a/tests/app/legacy/test_samples.py
+++ b/tests/app/legacy/test_samples.py
@@ -59,16 +59,49 @@ async def test_sample_notification(
 
 async def test_sample_notification_with_session(
     no_commit_session: AsyncSession,
+    sample_api_key: Callable[..., Awaitable[Row[Any]]],
     sample_notification: Callable[..., Awaitable[Row[Any]]],
+    sample_service: Callable[..., Awaitable[Row[Any]]],
+    sample_template: Callable[..., Awaitable[Row[Any]]],
 ) -> None:
     """Call the sample_notification generator.
 
     Args:
         no_commit_session (AsyncSession): A non-commit test session
+        sample_api_key (Callable[..., Awaitable[Row[Any]]]): An API Key object as a an SQLAlchemy Row
         sample_notification (Callable[..., Awaitable[Row[Any]]]): A Notifcation  object as a an SQLAlchemy Row
+        sample_service (Callable[..., Awaitable[Row[Any]]]): A Service object as a an SQLAlchemy Row
+        sample_template (Callable[..., Awaitable[Row[Any]]]): An API Key object as a an SQLAlchemy Row
     """
     async with no_commit_session as session:
         await sample_notification(session)
+
+        # add existing service
+        service = await sample_service(session)
+        await sample_notification(session=session, service_id=service.id)
+
+        # add existing api_key
+        api_key = await sample_api_key(
+            session=session,
+            service_id=service.id,
+        )
+        await sample_notification(
+            session=session,
+            service_id=service.id,
+            api_key_id=api_key.id,
+        )
+
+        # add existing template
+        template = await sample_template(
+            session=session,
+            service_id=service.id,
+        )
+        await sample_notification(
+            session=session,
+            service_id=service.id,
+            api_key_id=api_key.id,
+            template_id=template.id,
+        )
 
 
 async def test_sample_user_with_session(
@@ -142,6 +175,3 @@ async def test_sample_template_with_session(
             service_id=service.id,
             created_by_id=service.created_by_id,
         )
-
-
-# TODO: Add additional session tests for existing service, template, and api_key

--- a/tests/app/legacy/test_samples.py
+++ b/tests/app/legacy/test_samples.py
@@ -46,6 +46,31 @@ async def test_sample_template(
     await sample_template()
 
 
+async def test_sample_notification(
+    sample_notification: Callable[..., Awaitable[Row[Any]]],
+) -> None:
+    """Call the sample_notification generator.
+
+    Args:
+        sample_notification (Callable[..., Awaitable[Row[Any]]]): A Notifcation  object as a an SQLAlchemy Row
+    """
+    await sample_notification()
+
+
+async def test_sample_notification_with_session(
+    no_commit_session: AsyncSession,
+    sample_notification: Callable[..., Awaitable[Row[Any]]],
+) -> None:
+    """Call the sample_notification generator.
+
+    Args:
+        no_commit_session (AsyncSession): A non-commit test session
+        sample_notification (Callable[..., Awaitable[Row[Any]]]): A Notifcation  object as a an SQLAlchemy Row
+    """
+    async with no_commit_session as session:
+        await sample_notification(session)
+
+
 async def test_sample_user_with_session(
     no_commit_session: AsyncSession,
     sample_user: Callable[..., Awaitable[Row[Any]]],
@@ -117,3 +142,6 @@ async def test_sample_template_with_session(
             service_id=service.id,
             created_by_id=service.created_by_id,
         )
+
+
+# TODO: Add additional session tests for existing service, template, and api_key


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue #283 

- Remove LegacyNotificationsDao from the pytest coverage omit list
  - `app/legacy/dao/notifications_dao.py`
- Add sample_notification fixture to create uncommitted notification (and dependencies)
- Add unit tests for sample_notification fixture
- Add commit_notification fixture to add a committed notification to the db with proper cleanup
- Add full test coverage for LegacyNotificationDao

**additional cleanup**

- renamed prepared_api_key to commit_api_key for consistency
- removed unneccesary (not used) recipient_identifier args left over from previous PR (per Evan)

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Local unit testing in isolation for coverage and in full to ensure all tests pass.

### Run in isolation `poetry run pytest tests/app/legacy/dao/test_notifications.py`

![image](https://github.com/user-attachments/assets/fcb3304b-38af-4d17-a405-631c4ec41467)

### Full battery of unit tests

![image](https://github.com/user-attachments/assets/92c6b2c2-af10-45e6-b23c-8030e10a2a56)

![image](https://github.com/user-attachments/assets/71c76622-5d2b-4dda-a1ec-8b6a78cd68b6)

### GHA unit tests passing

```
Required test coverage of 100.0% reached. Total coverage: 100.00%
============================= 478 passed in 8.52s ==============================
unit tests passed
```

### Deployed to ENP DEV

- Test SMS delivered

### Unit test changes only / no changes to live code

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
