### PR TITLE
#282 - Add tests and ensure full coverage for api_keys_dao

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ omit = [
     "app/logging/*",
     "app/main.py",
     "tests/app/test_main.py",
-    "app/legacy/dao/api_keys_dao.py",
     "app/legacy/dao/recipient_identifiers_dao.py",
     "app/legacy/dao/utils.py",
 ]


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR adds tests for the LegacyApiKeysDao class and its current functions. 

- removed skipping of the `app/legacy/dao/api_keys_dao.py` file for code coverage in `pyproject.toml`
- added test to achieve 100% test coverage

issue #282 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [x] unit tests pass with 100% coverage

<img width="935" height="122" alt="image" src="https://github.com/user-attachments/assets/44c361a7-7a1c-4ff4-bd11-0b5bc6fddc57" />

- [x] 100% coverage of `app/legacy/dao/api_keys_dao.py` file when running only `tests/app/legacy/dao/test_api_keys.py`

<img width="682" height="27" alt="image" src="https://github.com/user-attachments/assets/1fbaa67a-6f70-4a3c-aabf-696fc139e8a3" />

GHA

```
----------------------------------------------------------------------------------------
TOTAL                                                     3954      0  100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
============================= 529 passed in 8.71s ==============================
unit tests passed
```

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
