### PR TITLE
#285 - Add test and ensure full coverage for legacy DAO utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ omit = [
     "app/main.py",
     "tests/app/test_main.py",
     "app/legacy/dao/recipient_identifiers_dao.py",
-    "app/legacy/dao/utils.py",
 ]
 
 [tool.coverage.report]

--- a/tests/app/legacy/dao/test_utils.py
+++ b/tests/app/legacy/dao/test_utils.py
@@ -1,0 +1,38 @@
+"""Tests for DAO utils methods."""
+
+from typing import Union
+
+import pytest
+
+from app.legacy.dao.utils import Serializer
+
+PayloadType = Union[
+    str,
+    int,
+    float,
+    bool,
+    dict[str, str],
+    list[str],
+    None,
+]
+
+
+@pytest.mark.parametrize(
+    'payload',
+    [
+        'hello',
+        123,
+        3.14,
+        True,
+        None,
+        {'foo': 'bar'},
+        ['a', 'b', 'c'],
+    ],
+)
+def test_serialize_deserialize_round_trip(payload: PayloadType) -> None:
+    """Test that serializer can perform a round-trip serialize/deserialize."""
+    serializer = Serializer()
+
+    encoded = serializer.serialize(payload)
+    decoded = serializer.deserialize(encoded)
+    assert decoded == payload


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR adds test for DAO utils Serializer to ensure 100% code coverage in app/legacy/dao/utils.py

- removed skipping of the `app/legacy/dao/utils.py` file for code coverage in `pyproject.toml`
- added test to achieve 100% test coverage
- added __init__.py to tests/app/legacy/dao to avoid import shadowing with other utils testing in the codebase

issue #285 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [x] unit tests pass with 100% coverage

<img width="962" height="102" alt="image" src="https://github.com/user-attachments/assets/5b7dc9e1-dbc4-4d18-99b8-02dbe55cafa4" />

- [x] 100% coverage of `app/legacy/dao/utils.py` file when running only `tests/app/legacy/dao/test_utils.py`

<img width="645" height="22" alt="image" src="https://github.com/user-attachments/assets/7040dca2-991c-44e0-a9d9-f909c76124f0" />


GHA

```

```

## Checklist

- [ ] I have assigned myself to this PR
- [ ] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [ ] PR has a detailed description, including links to specific documentation
- [ ] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [ ] I did not remove any parts of the template, such as checkboxes even if they are not used
- [ ] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [ ] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
